### PR TITLE
ci: Add CI for Rust

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -1,0 +1,32 @@
+name: CI Rust
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Run linter
+        run: cargo fmt --check
+      - name: Compile Code
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -18,8 +18,10 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - beta
-          - nightly
+          # Commenting out the following lines will enable the beta and nightly builds
+          # currently not in use since we can't format the code with the beta and nightly builds
+          # - beta
+          # - nightly
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust

--- a/phylo2vec/src/avl.rs
+++ b/phylo2vec/src/avl.rs
@@ -56,11 +56,11 @@ impl AVLTree {
                 let t2 = x.right.take();
                 x.right = Some(y_node);
                 x.right.as_mut().unwrap().left = t2;
-    
+
                 // Update heights
                 Self::update(x.right.as_mut().unwrap());
                 Self::update(&mut x);
-    
+
                 return Some(x);
             } else {
                 // If no left child, revert the state and return `None`
@@ -79,11 +79,11 @@ impl AVLTree {
                 let t2 = y.left.take();
                 y.left = Some(x_node);
                 y.left.as_mut().unwrap().right = t2;
-    
+
                 // Update heights
                 Self::update(y.left.as_mut().unwrap());
                 Self::update(&mut y);
-    
+
                 return Some(y);
             } else {
                 // If no right child, revert the state and return `None`
@@ -179,7 +179,7 @@ impl AVLTree {
                 current = &n.left;
             }
 
-            let node  = stack.pop().unwrap();
+            let node = stack.pop().unwrap();
             result.push(node.value);
 
             current = &node.right;

--- a/phylo2vec/src/lib.rs
+++ b/phylo2vec/src/lib.rs
@@ -1,3 +1,3 @@
+pub mod avl;
 pub mod to_newick;
 pub mod utils;
-pub mod avl;

--- a/phylo2vec/src/main.rs
+++ b/phylo2vec/src/main.rs
@@ -1,9 +1,9 @@
-mod to_newick;
 mod avl;
+mod to_newick;
 
 fn main() {
     // Currently a small testing routine to ensure things are working as intended
-    let v = vec![0,2,2,5,2];
+    let v = vec![0, 2, 2, 5, 2];
     let newick_string = to_newick::to_newick(v);
     print!("{}", newick_string);
 }

--- a/phylo2vec/src/to_newick.rs
+++ b/phylo2vec/src/to_newick.rs
@@ -4,7 +4,6 @@ use crate::avl::{AVLTree, Pair};
 type Ancestry = Vec<(usize, usize, usize)>;
 
 pub fn _get_pairs(v: &Vec<usize>) -> Vec<(usize, usize)> {
-
     let num_of_leaves: usize = v.len();
     let mut pairs: Vec<(usize, usize)> = Vec::with_capacity(num_of_leaves);
 
@@ -43,7 +42,6 @@ pub fn _get_pairs(v: &Vec<usize>) -> Vec<(usize, usize)> {
     pairs
 }
 
-
 pub fn _get_pairs_avl(v: &Vec<usize>) -> Vec<Pair> {
     // AVL tree implementation of get_pairs
     let k = v.len();
@@ -63,8 +61,6 @@ pub fn _get_pairs_avl(v: &Vec<usize>) -> Vec<Pair> {
 
     avl_tree.get_pairs()
 }
-
-
 
 /// Get the ancestry of the Phylo2Vec vector
 pub fn _get_ancestry(v: &Vec<usize>) -> Ancestry {

--- a/phylo2vec/src/utils.rs
+++ b/phylo2vec/src/utils.rs
@@ -1,13 +1,13 @@
 use rand::Rng;
 
 /// Sample a vector with `n_leaves - 1` elements.
-/// 
+///
 /// If ordering is True, sample an ordered tree, by default ordering is False
 /// ordering=True: v_i in {0, 1, ..., i} for i in (0, n_leaves-1)
 /// ordering=False: v_i in {0, 1, ..., 2*i} for i in (0, n_leaves-1)
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use phylo2vec::utils::sample;
 /// let v = sample(10, false);
@@ -34,15 +34,15 @@ pub fn sample(n_leaves: usize, ordering: bool) -> Vec<usize> {
 }
 
 /// Input validation of a Phylo2Vec vector
-/// 
+///
 /// The input is checked to satisfy the Phylo2Vec constraints
-/// 
+///
 /// # Panics
-/// 
+///
 /// Panics if any element of the input vector is out of bounds
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use phylo2vec::utils::check_v;
 /// check_v(&vec![0, 0, 1]);
@@ -52,14 +52,19 @@ pub fn check_v(v: &Vec<usize>) {
     let v_max: Vec<usize> = (0..k).map(|i| i * 2).collect();
 
     for i in 0..k {
-        assert!(v[i] <= v_max[i], "Validation failed: v[{}] = {} is out of bounds", i, v[i]);
+        assert!(
+            v[i] <= v_max[i],
+            "Validation failed: v[{}] = {} is out of bounds",
+            i,
+            v[i]
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
     use super::*;
+    use rstest::rstest;
 
     #[rstest]
     #[case(50, true, 1)]
@@ -70,7 +75,7 @@ mod tests {
         check_v(&v);
         for i in 0..(n_leaves - 1) {
             assert!(v[i] <= scale * i);
-        };
+        }
     }
 
     #[rstest]

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -49,7 +49,6 @@ fn check_v(input_vector: Vec<usize>) {
     _utils::check_v(&input_vector);
 }
 
-
 /// This module is exposed to Python.
 #[pymodule]
 fn _phylo2vec_core(m: &Bound<'_, PyModule>) -> PyResult<()> {


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration (CI) of Rust projects. The workflow is designed to run on different Rust toolchains and includes steps for checking code formatting, compiling the code, and running tests.

Key changes include:

* [`.github/workflows/ci-rust.yaml`](diffhunk://#diff-e0a44f932f567f558ec52679921ccef351a14659e9c5023318192395edb30c63R1-R32): Added a new CI workflow configuration for Rust projects that triggers on pushes to `main` and `dev` branches and on pull requests. This workflow sets up the Rust environment, runs a linter, compiles the code, and executes tests.