### PR TITLE
ci: Remove CD running on PRs

### DIFF
--- a/.github/workflows/cd-python.yaml
+++ b/.github/workflows/cd-python.yaml
@@ -7,7 +7,6 @@ on:
       - dev
     tags:
       - '*'
-  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/cd-python.yaml` file. The change removes the `pull_request` trigger from the workflow configuration.

* [`.github/workflows/cd-python.yaml`](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265L10): Removed the `pull_request` trigger from the `on:` section of the workflow configuration.