### PR TITLE
docs: Add a small readme for rust directory

### DIFF
--- a/phylo2vec/README.md
+++ b/phylo2vec/README.md
@@ -3,7 +3,7 @@
 This directory contains the core codebase for the phylo2vec written in Rust.
 
 If you are not familiar with Rust, there are several subdirectories that are important
-within this directory, as well as as configuration file to be aware of:
+within this directory, as well as a configuration file to be aware of:
 
 ```console
 .

--- a/phylo2vec/README.md
+++ b/phylo2vec/README.md
@@ -1,6 +1,6 @@
 # phylo2vec-rust
 
-This directory contains the core codebase for the phylo2vec written in Rust.
+This directory contains the core codebase for `phylo2vec` package written in Rust.
 
 If you are not familiar with Rust, there are several subdirectories that are important
 within this directory, as well as a configuration file to be aware of:

--- a/phylo2vec/README.md
+++ b/phylo2vec/README.md
@@ -1,0 +1,18 @@
+# phylo2vec-rust
+
+This directory contains the core codebase for the phylo2vec written in Rust.
+
+If you are not familiar with Rust, there are several subdirectories that are important
+within this directory, as well as as configuration file to be aware of:
+
+```console
+.
+├── Cargo.toml  # This is the Rust Cargo Manifest containing the needed metadata to compile the package
+├── README.md # This README you're reading
+├── benches/ # This subdirectory contains code to perform benchmarking on the Rust package
+└── src/ # This subdirectory is where the source code is located
+```
+
+For more information about the Cargo Manifest, check out the 
+[Official Cargo Documentation](https://doc.rust-lang.org/cargo/reference/manifest.html) on it.
+


### PR DESCRIPTION
This pull request includes a new `README.md` file for the `phylo2vec` project written in Rust. The main changes include the addition of a project description and details about the directory structure and important files.

Documentation improvements:

* [`phylo2vec/README.md`](diffhunk://#diff-221eb145ead49aa0366836a39ede41088d6098ddbb9cb7db4dccad8cd5a50ecfR1-R18): Added a comprehensive description of the `phylo2vec` project, including information about the Rust codebase, important subdirectories (`benches/`, `src/`), and the `Cargo.toml` configuration file.