### PR TITLE
style: Perform style fix on phylo2vec readme

### DIFF
--- a/phylo2vec/README.md
+++ b/phylo2vec/README.md
@@ -1,9 +1,10 @@
 # phylo2vec-rust
 
-This directory contains the core codebase for `phylo2vec` package written in Rust.
+This directory contains the core codebase for `phylo2vec` package written in
+Rust.
 
-If you are not familiar with Rust, there are several subdirectories that are important
-within this directory, as well as a configuration file to be aware of:
+If you are not familiar with Rust, there are several subdirectories that are
+important within this directory, as well as a configuration file to be aware of:
 
 ```console
 .
@@ -13,6 +14,6 @@ within this directory, as well as a configuration file to be aware of:
 └── src/ # This subdirectory is where the source code is located
 ```
 
-For more information about the Cargo Manifest, check out the 
-[Official Cargo Documentation](https://doc.rust-lang.org/cargo/reference/manifest.html) on it.
-
+For more information about the Cargo Manifest, check out the
+[Official Cargo Documentation](https://doc.rust-lang.org/cargo/reference/manifest.html)
+on it.


### PR DESCRIPTION
This pull request includes a minor change to the `phylo2vec/README.md` file to improve readability by breaking long lines into shorter ones.

Documentation improvements:

* [`phylo2vec/README.md`](diffhunk://#diff-221eb145ead49aa0366836a39ede41088d6098ddbb9cb7db4dccad8cd5a50ecfL3-R7): Reformatted long lines to improve readability. [[1]](diffhunk://#diff-221eb145ead49aa0366836a39ede41088d6098ddbb9cb7db4dccad8cd5a50ecfL3-R7) [[2]](diffhunk://#diff-221eb145ead49aa0366836a39ede41088d6098ddbb9cb7db4dccad8cd5a50ecfL17-R19)