### PR TITLE
refactor: Perform codebase refactor to separate appropriate functions

### DIFF
--- a/phylo2vec/benches/benchmarks/get_ancestry_dtype.rs
+++ b/phylo2vec/benches/benchmarks/get_ancestry_dtype.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use criterion::{criterion_group, BenchmarkId, Criterion};
 use phylo2vec::tree_vec::ops;
+use phylo2vec::tree_vec::types::PairsVec;
 use phylo2vec::utils::{is_unordered, sample};
 
 pub type AncestryTuple = Vec<(usize, usize, usize)>;
@@ -37,7 +38,7 @@ fn compare_get_ancestry_datatypes(c: &mut Criterion) {
 }
 
 pub fn get_ancestry_tuple(v: &Vec<usize>) -> AncestryTuple {
-    let pairs: ops::vector::PairsVec;
+    let pairs: PairsVec;
 
     // Determine the implementation to use
     // based on whether this is an ordered
@@ -83,7 +84,7 @@ pub fn get_ancestry_tuple(v: &Vec<usize>) -> AncestryTuple {
 }
 
 pub fn get_ancestry_vec(v: &Vec<usize>) -> AncestryVec {
-    let pairs: ops::vector::PairsVec;
+    let pairs: PairsVec;
 
     // Determine the implementation to use
     // based on whether this is an ordered
@@ -129,7 +130,7 @@ pub fn get_ancestry_vec(v: &Vec<usize>) -> AncestryVec {
 }
 
 pub fn get_ancestry_ndarray(v: &Vec<usize>) -> AncestryNDArray {
-    let pairs: ops::vector::PairsVec;
+    let pairs: PairsVec;
 
     // Determine the implementation to use
     // based on whether this is an ordered

--- a/phylo2vec/src/tree_vec/mod.rs
+++ b/phylo2vec/src/tree_vec/mod.rs
@@ -1,9 +1,10 @@
 use crate::utils::sample;
 
+// Import the types module
+pub mod types;
+
+// Import the operations modules
 pub mod ops;
-use ops::{
-    build_vector, find_coords_of_first_leaf, order_cherries, order_cherries_no_parents, Ancestry,
-};
 
 /// A vector representation of a phylogenetic tree
 ///
@@ -68,7 +69,7 @@ impl TreeVec {
     ///
     /// # Returns
     /// An `Ancestry` type containing parent-child relationships
-    pub fn get_ancestry(&self) -> Ancestry {
+    pub fn get_ancestry(&self) -> types::Ancestry {
         return ops::get_ancestry(&self.data);
     }
 
@@ -102,9 +103,9 @@ impl TreeVec {
 
         // ancestry_add[leaf_coords][leaf_col] = leaf as isize;
         // let ancestry_add_ref = &mut ancestry_add;
-        order_cherries(&mut ancestry_add);
-        order_cherries_no_parents(&mut ancestry_add);
-        self.data = build_vector(ancestry_add);
+        ops::order_cherries(&mut ancestry_add);
+        ops::order_cherries_no_parents(&mut ancestry_add);
+        self.data = ops::build_vector(ancestry_add);
     }
 
     /// Removes a leaf from the tree
@@ -119,7 +120,7 @@ impl TreeVec {
     /// Modifies the tree structure by removing the leaf and updating indices
     pub fn remove_leaf(&mut self, leaf: usize) -> usize {
         let ancestry = self.get_ancestry();
-        let leaf_coords = find_coords_of_first_leaf(&ancestry, leaf);
+        let leaf_coords = ops::find_coords_of_first_leaf(&ancestry, leaf);
         let leaf_row = leaf_coords.0;
         let leaf_col = leaf_coords.1;
 
@@ -159,9 +160,9 @@ impl TreeVec {
             ancestry_rm.push(new_row);
         }
 
-        order_cherries(&mut ancestry_rm);
-        order_cherries_no_parents(&mut ancestry_rm);
-        self.data = build_vector(ancestry_rm);
+        ops::order_cherries(&mut ancestry_rm);
+        ops::order_cherries_no_parents(&mut ancestry_rm);
+        self.data = ops::build_vector(ancestry_rm);
 
         return sister;
     }
@@ -232,7 +233,7 @@ mod tests {
     #[case(vec![0, 0, 1], vec![[1, 3, 4],
         [0, 2, 5],
         [5, 4, 6]])]
-    fn test_get_ancestry(#[case] v: Vec<usize>, #[case] expected: Ancestry) {
+    fn test_get_ancestry(#[case] v: Vec<usize>, #[case] expected: types::Ancestry) {
         let tree = TreeVec::new(v, None, None);
         let ancestry = tree.get_ancestry();
         assert_eq!(ancestry, expected);

--- a/phylo2vec/src/tree_vec/ops/avl.rs
+++ b/phylo2vec/src/tree_vec/ops/avl.rs
@@ -1,5 +1,4 @@
-// Node definition
-pub type Pair = (usize, usize);
+use crate::tree_vec::types::Pair;
 
 pub struct Node {
     value: Pair,

--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -1,8 +1,18 @@
 pub mod avl;
+pub mod newick;
 pub mod vector;
 
-#[allow(unused_imports)]
+use crate::tree_vec::types::Ancestry;
+
 pub use vector::{
-    build_newick, build_vector, find_coords_of_first_leaf, get_ancestry, get_pairs, get_pairs_avl,
-    order_cherries, order_cherries_no_parents, to_newick, Ancestry,
+    build_vector, find_coords_of_first_leaf, get_ancestry, get_pairs, get_pairs_avl,
+    order_cherries, order_cherries_no_parents,
 };
+
+pub use newick::build_newick;
+
+/// Recover a rooted tree (in Newick format) from a Phylo2Vec vector
+pub fn to_newick(v: &Vec<usize>) -> String {
+    let ancestry: Ancestry = get_ancestry(&v);
+    build_newick(&ancestry)
+}

--- a/phylo2vec/src/tree_vec/ops/newick.rs
+++ b/phylo2vec/src/tree_vec/ops/newick.rs
@@ -1,0 +1,34 @@
+use crate::tree_vec::types::Ancestry;
+
+// The recursive function that builds the Newick string
+fn _build_newick_recursive_inner(p: usize, ancestry: &Ancestry) -> String {
+    let leaf_max = ancestry.len();
+
+    // Extract the children (c1, c2) and ignore the parent from the ancestry tuple
+    let [c1, c2, _] = ancestry[p - leaf_max - 1];
+
+    // Recursive calls for left and right children, checking if they are leaves or internal nodes
+    let left = if c1 > leaf_max {
+        _build_newick_recursive_inner(c1, ancestry)
+    } else {
+        c1.to_string() // It's a leaf node, just convert to string
+    };
+
+    let right = if c2 > leaf_max {
+        _build_newick_recursive_inner(c2, ancestry)
+    } else {
+        c2.to_string() // It's a leaf node, just convert to string
+    };
+
+    // Create the Newick string in the form (left, right)p
+    format!("({},{}){}", left, right, p)
+}
+
+/// Build newick string from the ancestry matrix
+pub fn build_newick(ancestry: &Ancestry) -> String {
+    // Get the root node, which is the parent value of the last ancestry element
+    let root = ancestry.last().unwrap()[2];
+
+    // Build the Newick string starting from the root, and append a semicolon
+    format!("{};", _build_newick_recursive_inner(root, ancestry))
+}

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -1,12 +1,7 @@
-use crate::tree_vec::ops::avl::{AVLTree, Pair};
+use crate::tree_vec::ops::avl::AVLTree;
+use crate::tree_vec::types::{Ancestry, Pair, PairsVec};
 use crate::utils::is_unordered;
 use std::usize;
-
-/// A type alias for the Ancestry type, which is a vector of vectors representing [child1, child2, parent]
-pub type Ancestry = Vec<[usize; 3]>;
-
-/// A type alias for the PairsVec type, which is a vector of tuples representing (child1, child2)
-pub type PairsVec = Vec<Pair>;
 
 /// Get the pair of nodes from the Phylo2Vec vector
 /// using a vector data structure and for loops
@@ -148,45 +143,6 @@ pub fn get_ancestry(v: &Vec<usize>) -> Ancestry {
     }
 
     ancestry
-}
-
-// The recursive function that builds the Newick string
-fn _build_newick_recursive_inner(p: usize, ancestry: &Ancestry) -> String {
-    let leaf_max = ancestry.len();
-
-    // Extract the children (c1, c2) and ignore the parent from the ancestry tuple
-    let [c1, c2, _] = ancestry[p - leaf_max - 1];
-
-    // Recursive calls for left and right children, checking if they are leaves or internal nodes
-    let left = if c1 > leaf_max {
-        _build_newick_recursive_inner(c1, ancestry)
-    } else {
-        c1.to_string() // It's a leaf node, just convert to string
-    };
-
-    let right = if c2 > leaf_max {
-        _build_newick_recursive_inner(c2, ancestry)
-    } else {
-        c2.to_string() // It's a leaf node, just convert to string
-    };
-
-    // Create the Newick string in the form (left, right)p
-    format!("({},{}){}", left, right, p)
-}
-
-/// Build newick string from the ancestry matrix
-pub fn build_newick(ancestry: &Ancestry) -> String {
-    // Get the root node, which is the parent value of the last ancestry element
-    let root = ancestry.last().unwrap()[2];
-
-    // Build the Newick string starting from the root, and append a semicolon
-    format!("{};", _build_newick_recursive_inner(root, ancestry))
-}
-
-/// Recover a rooted tree (in Newick format) from a Phylo2Vec vector
-pub fn to_newick(v: &Vec<usize>) -> String {
-    let ancestry: Ancestry = get_ancestry(&v);
-    build_newick(&ancestry)
 }
 
 pub fn find_coords_of_first_leaf(ancestry: &Ancestry, leaf: usize) -> (usize, usize) {

--- a/phylo2vec/src/tree_vec/types.rs
+++ b/phylo2vec/src/tree_vec/types.rs
@@ -1,0 +1,8 @@
+// A type alias for the Pair type, which is a tuple representing (child1, child2)
+pub type Pair = (usize, usize);
+
+/// A type alias for the Ancestry type, which is a vector of vectors representing [child1, child2, parent]
+pub type Ancestry = Vec<[usize; 3]>;
+
+/// A type alias for the PairsVec type, which is a vector of tuples representing (child1, child2)
+pub type PairsVec = Vec<Pair>;

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -32,7 +32,7 @@ fn get_pairs_avl(input_vector: Vec<usize>) -> Vec<(usize, usize)> {
 
 #[pyfunction]
 fn build_newick(input_ancestry: Vec<[usize; 3]>) -> String {
-    let newick_string: String = ops::vector::build_newick(&input_ancestry);
+    let newick_string: String = ops::newick::build_newick(&input_ancestry);
     newick_string
 }
 


### PR DESCRIPTION
This pull request involves several changes to the `phylo2vec` library, focusing on code organization and refactoring. The primary changes include moving type definitions to a new `types` module, updating import paths, and refactoring functions to use the new module. Additionally, a new `newick` module has been introduced to handle Newick string construction.

### Code Organization and Refactoring:

* [`phylo2vec/src/tree_vec/mod.rs`](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9R3-L6): Introduced a new `types` module and updated type references to use this module. [[1]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9R3-L6) [[2]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L71-R72) [[3]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L105-R108) [[4]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L122-R123) [[5]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L162-R165) [[6]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L235-R236)
* [`phylo2vec/src/tree_vec/ops/mod.rs`](diffhunk://#diff-981749b2e0b574fedc34b8672f862e4d574c2b97eb58220bc6cd3af30cb06a3aR2-R18): Added a new `newick` module and refactored the `to_newick` function to use this module.
* [`phylo2vec/src/tree_vec/ops/vector.rs`](diffhunk://#diff-121649f3c42bdce021f4118590bc2832ab387ba3998f82270cd2bfc6aaa75a4bL1-L10): Removed type aliases and Newick string construction functions, which were moved to the new `types` and `newick` modules respectively. [[1]](diffhunk://#diff-121649f3c42bdce021f4118590bc2832ab387ba3998f82270cd2bfc6aaa75a4bL1-L10)R1, [[2]](diffhunk://#diff-121649f3c42bdce021f4118590bc2832ab387ba3998f82270cd2bfc6aaa75a4bL153-L191)
* [`phylo2vec/src/tree_vec/types.rs`](diffhunk://#diff-f4705f06fa284130a344a1848730e8e83c13615cd90afe632e92faa15f0b402fR1-R8): Created a new `types` module to define type aliases for `Pair`, `Ancestry`, and `PairsVec`.

### Function and Type Updates:

* [`phylo2vec/benches/benchmarks/get_ancestry_dtype.rs`](diffhunk://#diff-457395655697613ca5153ae7921fdcbf493413050038b7bc7cb198418138d6e6R6): Updated type references from `ops::vector::PairsVec` to `PairsVec`. [[1]](diffhunk://#diff-457395655697613ca5153ae7921fdcbf493413050038b7bc7cb198418138d6e6R6) [[2]](diffhunk://#diff-457395655697613ca5153ae7921fdcbf493413050038b7bc7cb198418138d6e6L40-R41) [[3]](diffhunk://#diff-457395655697613ca5153ae7921fdcbf493413050038b7bc7cb198418138d6e6L86-R87) [[4]](diffhunk://#diff-457395655697613ca5153ae7921fdcbf493413050038b7bc7cb198418138d6e6L132-R133)
* [`py-phylo2vec/src/lib.rs`](diffhunk://#diff-fcbbbb9f40d0315e4c8e2e2ff1d1442a362cabd52536ccba44526e369e866996L35-R35): Updated the `build_newick` function to use the new `ops::newick::build_newick` function.

## Related Issues

Closes #50 