### PR TITLE
feat: Add from_newick function to parse newick string

### DIFF
--- a/phylo2vec/src/tree_vec/mod.rs
+++ b/phylo2vec/src/tree_vec/mod.rs
@@ -105,7 +105,7 @@ impl TreeVec {
         // let ancestry_add_ref = &mut ancestry_add;
         ops::order_cherries(&mut ancestry_add);
         ops::order_cherries_no_parents(&mut ancestry_add);
-        self.data = ops::build_vector(ancestry_add);
+        self.data = ops::build_vector(&ancestry_add);
     }
 
     /// Removes a leaf from the tree
@@ -162,7 +162,7 @@ impl TreeVec {
 
         ops::order_cherries(&mut ancestry_rm);
         ops::order_cherries_no_parents(&mut ancestry_rm);
-        self.data = ops::build_vector(ancestry_rm);
+        self.data = ops::build_vector(&ancestry_rm);
 
         return sister;
     }

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -1,7 +1,6 @@
 use crate::tree_vec::ops::avl::AVLTree;
 use crate::tree_vec::types::{Ancestry, Pair, PairsVec};
 use crate::utils::is_unordered;
-use std::collections::HashMap;
 use std::usize;
 
 /// Get the pair of nodes from the Phylo2Vec vector
@@ -231,24 +230,26 @@ pub fn order_cherries_no_parents(ancestry: &mut Ancestry) {
 
 pub fn build_vector(cherries: &Ancestry) -> Vec<usize> {
     let num_cherries = cherries.len();
-    let mut v: Vec<usize> = vec![0; num_cherries];
+    let num_leaves = num_cherries + 1;
+
+    let mut v = vec![0; num_cherries];
+    let mut idxs = vec![0; num_leaves];
 
     for i in 0..num_cherries {
         let [c1, c2, c_max] = cherries[i];
 
         let mut idx = 0;
 
-        for j in 0..i {
-            if cherries[j][2] <= c_max {
-                idx += 1;
-            }
+        for j in 1..c_max {
+            idx += idxs[j];
         }
-
+        // Reminder: v[i] = j --> branch i yields leaf j
         v[c_max - 1] = if idx == 0 {
             std::cmp::min(c1, c2)
         } else {
             c_max - 1 + idx
         };
+        idxs[c_max] = 1;
     }
     return v;
 }

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -231,7 +231,7 @@ pub fn order_cherries_no_parents(ancestry: &mut Ancestry) {
 
 pub fn build_vector(cherries: &Ancestry) -> Vec<usize> {
     let num_cherries = cherries.len();
-    let mut v_res: Vec<usize> = vec![0; num_cherries];
+    let mut v: Vec<usize> = vec![0; num_cherries];
 
     for i in 0..num_cherries {
         let [c1, c2, c_max] = cherries[i];
@@ -244,11 +244,11 @@ pub fn build_vector(cherries: &Ancestry) -> Vec<usize> {
             }
         }
 
-        v_res[c_max - 1] = if idx == 0 {
+        v[c_max - 1] = if idx == 0 {
             std::cmp::min(c1, c2)
         } else {
             c_max - 1 + idx
         };
     }
-    return v_res;
+    return v;
 }

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -159,20 +159,35 @@ pub fn find_coords_of_first_leaf(ancestry: &Ancestry, leaf: usize) -> (usize, us
 
 pub fn order_cherries(ancestry: &mut Ancestry) {
     let num_cherries = ancestry.len();
+    let num_nodes = 2 * num_cherries + 2;
+
+    let mut min_desc = vec![usize::MAX; num_nodes];
 
     // Sort by the parent node (ascending order)
     ancestry.sort_by_key(|x| x[2]);
 
-    let mut small_children: HashMap<usize, usize> = HashMap::new();
-
     for i in 0..num_cherries {
         let [c1, c2, p] = ancestry[i];
+        // Get the minimum descendant of c1 and c2 (if they exist)
+        // min_desc[child_x] doesn't exist, min_desc_x --> child_x
+        let min_desc1 = if min_desc[c1] != usize::MAX {
+            min_desc[c1]
+        } else {
+            c1
+        };
+        let min_desc2 = if min_desc[c2] != usize::MAX {
+            min_desc[c2]
+        } else {
+            c2
+        };
 
-        let parent_c1 = *small_children.get(&c1).unwrap_or(&c1);
-        let parent_c2 = *small_children.get(&c2).unwrap_or(&c2);
-        small_children.insert(p, std::cmp::min(parent_c1, parent_c2));
+        // Collect the minimum descendant and allocate it to min_desc[parent]
+        let desc_min = std::cmp::min(min_desc1, min_desc2);
+        min_desc[p] = desc_min;
 
-        ancestry[i] = [parent_c1, parent_c2, std::cmp::max(parent_c1, parent_c2)];
+        // Instead of the parent, we collect the max node
+        let desc_max = std::cmp::max(min_desc1, min_desc2);
+        ancestry[i] = [min_desc1, min_desc2, desc_max];
     }
 }
 
@@ -237,40 +252,3 @@ pub fn build_vector(cherries: &Ancestry) -> Vec<usize> {
     }
     return v_res;
 }
-
-// NOTE (Don.S 12/11/2024): This is cpp implementation.. commenting out for now in case we need it later
-// for this implementation, HashMap is not used. Instead, we use a vector to store the minimum descendant.
-//
-// pub fn order_cherries(ancestry: &mut Ancestry) {
-//     let num_cherries = ancestry.len();
-//     let num_nodes = 2 * num_cherries + 2;
-
-//     let mut min_desc = vec![usize::MAX; num_nodes];
-
-//     // Sort by the parent node (ascending order)
-//     ancestry.sort_by_key(|x| x[2]);
-
-//     for i in 0..num_cherries {
-//         let [c1, c2, p] = ancestry[i];
-//         // Get the minimum descendant of c1 and c2 (if they exist)
-//         // min_desc[child_x] doesn't exist, min_desc_x --> child_x
-//         let min_desc1 = if min_desc[c1] != usize::MAX {
-//             min_desc[c1]
-//         } else {
-//             c1
-//         };
-//         let min_desc2 = if min_desc[c2] != usize::MAX {
-//             min_desc[c2]
-//         } else {
-//             c2
-//         };
-
-//         // Collect the minimum descendant and allocate it to min_desc[parent]
-//         let desc_min = std::cmp::min(min_desc1, min_desc2);
-//         min_desc[p] = desc_min;
-
-//         // Instead of the parent, we collect the max node
-//         let desc_max = std::cmp::max(min_desc1, min_desc2);
-//         ancestry[i] = [min_desc1, min_desc2, desc_max];
-//     }
-// }


### PR DESCRIPTION
This pull request introduces several changes to the `phylo2vec` module, focusing on improving the handling of Newick format trees and the corresponding vector operations. The most important changes include the addition of a function to convert Newick format strings to vectors, updates to vector construction functions, and the addition of tests for these new functionalities.

### New functionality:
* [`phylo2vec/src/tree_vec/ops/mod.rs`](diffhunk://#diff-981749b2e0b574fedc34b8672f862e4d574c2b97eb58220bc6cd3af30cb06a3aR19-R78): Added `from_newick` function to convert Newick format strings to vectors, with an option to handle trees with or without parent nodes.

### Vector construction updates:
* [`phylo2vec/src/tree_vec/mod.rs`](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L108-R108): Updated calls to `build_vector` to pass references instead of values for better performance. [[1]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L108-R108) [[2]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L165-R165)
* [`phylo2vec/src/tree_vec/ops/vector.rs`](diffhunk://#diff-121649f3c42bdce021f4118590bc2832ab387ba3998f82270cd2bfc6aaa75a4bL231-L252): Modified `build_vector` to accept a reference to `Ancestry` instead of taking ownership, improving efficiency.

### New tests:
* [`phylo2vec/src/tree_vec/ops/mod.rs`](diffhunk://#diff-981749b2e0b574fedc34b8672f862e4d574c2b97eb58220bc6cd3af30cb06a3aR19-R78): Added tests for converting vectors to Newick format and vice versa, including cases for trees with and without parent nodes.

### Internal function additions:
* [`phylo2vec/src/tree_vec/ops/newick.rs`](diffhunk://#diff-d40dd388ba94c23ecd81913a5e09058e2c21ebf2db1d648605d5366c409af537R3-R62): Added `_get_cherries_recursive_inner` to recursively parse Newick strings and extract ancestry information.

### Dependency updates:
* [`phylo2vec/src/tree_vec/ops/vector.rs`](diffhunk://#diff-121649f3c42bdce021f4118590bc2832ab387ba3998f82270cd2bfc6aaa75a4bR4): Added `HashMap` import for potential future use in vector operations.This pull request introduces several important changes to the `phylo2vec` module, including updates to the `TreeVec` implementation, new functionality for Newick format conversions, and optimizations in the vector operations. The most significant changes are summarized below:

### Enhancements and Bug Fixes in `TreeVec` Implementation:
* Modified `build_vector` calls to pass `ancestry_add` and `ancestry_rm` by reference in `impl TreeVec` to improve efficiency. (`phylo2vec/src/tree_vec/mod.rs`) [[1]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L108-R108) [[2]](diffhunk://#diff-93651a78de451eb71d57f7b5f50421603e29b7607e886401e3e60bc90d8c8de9L165-R165)

### New Functionality for Newick Format Conversions:
* Added `from_newick` function to convert a Newick format string to a `Phylo2Vec` vector, with support for trees with or without parent nodes. (`phylo2vec/src/tree_vec/ops/mod.rs`)
* Introduced unit tests for `to_newick`, `from_newick`, and `from_newick_no_parents` functions to ensure correctness of Newick format conversions. (`phylo2vec/src/tree_vec/ops/mod.rs`)

### Optimizations in Vector Operations:
* Implemented `_get_cherries_recursive_inner` function to recursively extract cherries from a Newick string, supporting both parent-inclusive and parent-exclusive formats. (`phylo2vec/src/tree_vec/ops/newick.rs`)
* Updated `order_cherries` to use a `HashMap` for tracking the smallest child nodes, which simplifies and optimizes the sorting process. (`phylo2vec/src/tree_vec/ops/vector.rs`)
* Refactored `build_vector` to accept a reference to `Ancestry` and optimized the vector construction logic. (`phylo2vec/src/tree_vec/ops/vector.rs`)

These changes collectively enhance the functionality, efficiency, and maintainability of the `phylo2vec` module.

## Related Issues
- Closes #55
- Closes #56 
- Closes #57 
- Closes #58 
- Closes #59