### PR TITLE
build: Fix build to be release for python dev rust compilation

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -62,16 +62,11 @@ jupyterlab = ">=4.1,<4.2"
 pytest = ">=8.3.4,<9"
 
 [feature.python.tasks.install-python]
-cmd = "maturin develop --manifest-path ./py-phylo2vec/Cargo.toml"
+cmd = "maturin develop --release --manifest-path ./py-phylo2vec/Cargo.toml"
 
 [feature.python.tasks.test]
 cmd = "pytest -vvv ./py-phylo2vec/tests"
 depends-on = ["install-python"]
-
-[feature.python.tasks.test-rust]
-cmd = "cargo test --lib"
-cwd = "py-phylo2vec"
-
 
 # ======== r-phylo2vec ===========
 


### PR DESCRIPTION
This pull request includes updates to the `pixi.toml` file, specifically focusing on the installation and testing commands for the Python tasks.

Key changes:

* Updated the `cmd` for the `install-python` task to include the `--release` flag, which ensures that the Python package is built in release mode.
* Removed the `test-rust` task, which previously ran Rust library tests in the `py-phylo2vec` directory.