### PR TITLE
docs: Add initial CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: "Scheidwasser"
+    given-names: "Neil"
+title: "Phylo2Vec: a vector representation for binary trees"
+url: "https://phylo2vec.readthedocs.io"
+repository-code: "https://github.com/sbhattlab/phylo2vec"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Penn"
+    given-names: "Matthew J"
+  - family-names: "Scheidwasser"
+    given-names: "Neil"
+  - family-names: "Khurana"
+    given-names: "Mark P"
+  - family-names: "Duchêne"
+    given-names: "David A"
+  - family-names: "Donnelly"
+    given-names: "Christl A"
+  - family-names: "Bhatt"
+    given-names: "Samir"
+  journal: "arXiv preprint arXiv:2304.12693v4"
+  doi: https://doi.org/10.48550/arXiv.2304.12693
+  month: 11
+  title: "Phylo2Vec: a vector representation for binary trees"
+  year: 2024


### PR DESCRIPTION
This pull request includes the addition of a new `CITATION.cff` file to provide citation information for the `Phylo2Vec` software. The file includes details about the version, authors, title, URL, repository, and preferred citation format for the software.

Citation information:

* Added `CITATION.cff` file with version 1.2.0, authors, title, URL, repository code, and preferred citation details for the `Phylo2Vec` software.

## Related Issues

Closes #72