### PR TITLE
ci: Add dependabot and release config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+changelog:
+  exclude:
+    authors:
+      - deepsource-io
+      - dependabot
+      - pre-commit-ci
+      - Copilot


### PR DESCRIPTION
This pull request includes updates to configuration files for GitHub Actions and release management. The most important changes include the addition of a Dependabot configuration file and the exclusion of certain authors from the changelog.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R11): Added a new configuration file to maintain dependencies for GitHub Actions with a weekly update schedule.
* [`.github/release.yml`](diffhunk://#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R1-R7): Updated the release configuration to exclude specific authors from the changelog.