### PR TITLE
feat: Integrate 'to_vector', removing '*_no_parents'

### DIFF
--- a/benchmarks/bench_sample_kl.py
+++ b/benchmarks/bench_sample_kl.py
@@ -22,7 +22,7 @@ from scipy import stats
 from tqdm import tqdm
 
 from benchmarks.plot import clear_axes, set_size
-from phylo2vec.base import to_vector_no_parents
+from phylo2vec.base import to_vector
 from phylo2vec.utils import sample
 
 plt.rcParams.update(
@@ -149,7 +149,7 @@ def generate_samples(n_repeats, n_times, min_leaves, max_leaves, step_leaves):
             # ape integers
             for j, nw in enumerate(newicks):
                 # Convert to Phylo2Vec vector
-                v = to_vector_no_parents(nw)
+                v = to_vector(nw)
 
                 all_ints_ape[k, i, j] = to_integer(v)
 

--- a/py-phylo2vec/phylo2vec/base/__init__.py
+++ b/py-phylo2vec/phylo2vec/base/__init__.py
@@ -3,6 +3,6 @@ Methods to convert Phylo2Vec vectors to Newick format and vice-versa.
 """
 
 from .to_newick import to_newick
-from .to_vector import to_vector, to_vector_no_parents
+from .to_vector import to_vector
 
-__all__ = ["to_newick", "to_vector", "to_vector_no_parents"]
+__all__ = ["to_newick", "to_vector"]

--- a/py-phylo2vec/phylo2vec/utils/vector.py
+++ b/py-phylo2vec/phylo2vec/utils/vector.py
@@ -11,7 +11,8 @@ from phylo2vec.base.to_newick import _get_ancestry, to_newick
 from phylo2vec.base.to_vector import (
     _build_vector,
     _find_cherries,
-    _order_cherries_no_parents
+    _order_cherries_no_parents,
+    to_vector,
 )
 from phylo2vec.utils.validation import check_v
 

--- a/py-phylo2vec/phylo2vec/utils/vector.py
+++ b/py-phylo2vec/phylo2vec/utils/vector.py
@@ -11,8 +11,7 @@ from phylo2vec.base.to_newick import _get_ancestry, to_newick
 from phylo2vec.base.to_vector import (
     _build_vector,
     _find_cherries,
-    _order_cherries_no_parents,
-    to_vector_no_parents,
+    _order_cherries_no_parents
 )
 from phylo2vec.utils.validation import check_v
 
@@ -223,11 +222,11 @@ def reroot_at_random(v):
 
     newick = ete3_tree.write(format=9)
 
-    v_new = to_vector_no_parents(newick)
+    v_new = to_vector(newick)
 
     check_v(v_new)
 
-    return to_vector_no_parents(newick)
+    return to_vector(newick)
 
 
 # faster than np.nonzero

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -11,6 +11,12 @@ fn to_newick(input_vector: Vec<usize>) -> PyResult<String> {
 }
 
 #[pyfunction]
+fn to_vector(newick: &str) -> Vec<usize> {
+    let v = ops::to_vector(&newick);
+    v
+}
+
+#[pyfunction]
 fn get_ancestry(input_vector: Vec<usize>) -> Vec<[usize; 3]> {
     let ancestry: Vec<[usize; 3]> = ops::get_ancestry(&input_vector);
 
@@ -38,6 +44,7 @@ fn check_v(input_vector: Vec<usize>) {
 #[pymodule]
 fn _phylo2vec_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(to_newick, m)?)?;
+    m.add_function(wrap_pyfunction!(to_vector, m)?)?;
     m.add_function(wrap_pyfunction!(build_newick, m)?)?;
     m.add_function(wrap_pyfunction!(get_ancestry, m)?)?;
     m.add_function(wrap_pyfunction!(sample, m)?)?;

--- a/py-phylo2vec/tests/test_v2newick2v.py
+++ b/py-phylo2vec/tests/test_v2newick2v.py
@@ -6,7 +6,7 @@ import pytest
 from ete3 import Tree
 
 from .config import MIN_N_LEAVES, MAX_N_LEAVES, N_REPEATS
-from phylo2vec.base import to_newick, to_vector, to_vector_no_parents
+from phylo2vec.base import to_newick, to_vector
 from phylo2vec.base.to_vector import (
     _find_cherries,
     _order_cherries_no_parents,
@@ -39,7 +39,7 @@ def test_v2newick2v(n_leaves):
 
 @pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))
 def test_cherries_no_parents(n_leaves):
-    """Test that the functions of to_vector_no_parents and to_vector do the same thing
+    """Test that the functions of to_vector handles parents and without
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def test_ladderize(n_leaves):
 
         nw_ladderized = tr.write(format=9)
 
-        assert np.array_equal(to_vector(nw), to_vector_no_parents(nw_ladderized))
+        assert np.array_equal(to_vector(nw), to_vector(nw_ladderized))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes significant refactoring and simplification of the `phylo2vec` codebase by removing the `to_vector_no_parents` function and consolidating its functionality into the `to_vector` function. Additionally, there are some type changes and updates to related tests and utility functions. The most important changes include the removal of `to_vector_no_parents`, updates to the `to_vector` function to handle both cases, and corresponding changes in imports and tests.

Refactoring and simplification:

* [`py-phylo2vec/phylo2vec/base/to_vector.py`](diffhunk://#diff-6288d4e90180e21cb9867043b4a6809e91adb0b4814ebcbf76ebcad75fef80c7L154-R156): Removed the `to_vector_no_parents` function and updated the `to_vector` function to handle Newick strings with or without parent labels.
* [`py-phylo2vec/phylo2vec/base/__init__.py`](diffhunk://#diff-6398f0a4c448a0d55174d0fe05c79ade1882858b159ae2be4b871f27255acc99L6-R8): Removed the import and reference to `to_vector_no_parents`.
* [`benchmarks/bench_sample_kl.py`](diffhunk://#diff-73c243a6de4a74027ff1893678009cb208fd769b528d9524c1c8e9fd851a0fa3L25-R25): Updated imports and function calls to use `to_vector` instead of `to_vector_no_parents`. [[1]](diffhunk://#diff-73c243a6de4a74027ff1893678009cb208fd769b528d9524c1c8e9fd851a0fa3L25-R25) [[2]](diffhunk://#diff-73c243a6de4a74027ff1893678009cb208fd769b528d9524c1c8e9fd851a0fa3L152-R152)

Type and utility updates:

* [`py-phylo2vec/phylo2vec/base/to_vector.py`](diffhunk://#diff-6288d4e90180e21cb9867043b4a6809e91adb0b4814ebcbf76ebcad75fef80c7L71-R71): Changed the types in the `_find_cherries` function from `int16` to `int64`.
* [`py-phylo2vec/phylo2vec/utils/vector.py`](diffhunk://#diff-b26f9b92e3479bf799a778421c5a2bf3b4928afb38c3d56db609cfd04bb0b997L14-R14): Updated function calls to use `to_vector` and removed references to `to_vector_no_parents`. [[1]](diffhunk://#diff-b26f9b92e3479bf799a778421c5a2bf3b4928afb38c3d56db609cfd04bb0b997L14-R14) [[2]](diffhunk://#diff-b26f9b92e3479bf799a778421c5a2bf3b4928afb38c3d56db609cfd04bb0b997L226-R229)

Test updates:

* [`py-phylo2vec/tests/test_v2newick2v.py`](diffhunk://#diff-eb4c05bf5b013bafc401b7eb9ae3e443401c62cbd4df4de5967e039ea3a0a183L9-R9): Updated tests to use `to_vector` and removed references to `to_vector_no_parents`. [[1]](diffhunk://#diff-eb4c05bf5b013bafc401b7eb9ae3e443401c62cbd4df4de5967e039ea3a0a183L9-R9) [[2]](diffhunk://#diff-eb4c05bf5b013bafc401b7eb9ae3e443401c62cbd4df4de5967e039ea3a0a183L42-R42) [[3]](diffhunk://#diff-eb4c05bf5b013bafc401b7eb9ae3e443401c62cbd4df4de5967e039ea3a0a183L110-R110)

## Related Issues

Closes #80