### PR TITLE
ci: Update CD to use trusted publishing

### DIFF
--- a/.github/workflows/cd-python.yaml
+++ b/.github/workflows/cd-python.yaml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
       - dev
-    tags:
-      - '*'
   workflow_dispatch:
+  release:
+    types:
+      - published
 
 permissions:
   contents: read
@@ -151,7 +152,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    # Set the PyPI environment,
+    # this needs to match the environment
+    # set in pypi website
+    environment: pypi
+    if: github.event_name == 'release' && github.event.action == 'published'
     needs: [linux, musllinux, windows, macos, sdist]
     permissions:
       # Use to sign the release artifacts
@@ -169,8 +174,6 @@ jobs:
       - name: Publish to PyPI
         if: "startsWith(github.ref, 'refs/tags/')"
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/cd-python.yaml` file to update the continuous deployment workflow for the Python project. The most important changes include modifying the trigger conditions for the workflow and updating the release job configuration.

Changes to workflow triggers:

* [`.github/workflows/cd-python.yaml`](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265L8-R11): Removed the `tags` trigger and added a `release` trigger with the `published` type.

Updates to release job configuration:

* [`.github/workflows/cd-python.yaml`](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265L154-R159): Added an `environment` parameter set to `pypi` and updated the `if` condition to check for a `release` event with the `published` action.
* [`.github/workflows/cd-python.yaml`](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265L172-L173): Removed the `env` block for `MATURIN_PYPI_TOKEN` in the `Publish to PyPI` step.

## Related Issues

Closes #86