### PR TITLE
ci: Add mising macos x86_64 build

### DIFF
--- a/.github/workflows/cd-python.yaml
+++ b/.github/workflows/cd-python.yaml
@@ -115,6 +115,8 @@ jobs:
     strategy:
       matrix:
         platform:
+          - runner: macos-13
+            target: x86_64
           - runner: macos-14
             target: aarch64
     steps:


### PR DESCRIPTION
This pull request includes a change to the continuous deployment workflow configuration for Python projects. The most important change is the addition of a new platform to the matrix strategy in the `.github/workflows/cd-python.yaml` file.

Changes to continuous deployment workflow:

* [`.github/workflows/cd-python.yaml`](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R118-R119): Added `macos-13` with `x86_64` target to the matrix strategy under `jobs:`.