### PR TITLE
refactor: Update 'is_unordered' to return early for first instance

### DIFF
--- a/phylo2vec/src/utils.rs
+++ b/phylo2vec/src/utils.rs
@@ -93,15 +93,14 @@ fn _check_max(idx: usize, value: usize) -> () {
 /// assert_eq!(unordered, false);
 /// ```
 pub fn is_unordered(v: &Vec<usize>) -> bool {
-    let mut unordered = false;
     for i in 0..v.len() {
         _check_max(i, v[i]);
         if v[i] > i + 1 {
-            unordered = true;
+            return true;
         }
     }
 
-    unordered
+    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request includes a change to the `is_unordered` function in the `phylo2vec/src/utils.rs` file to improve its efficiency. The most important change is the modification of the function to return immediately when an unordered element is found, instead of using a flag to track the state.

Efficiency improvement:

* [`phylo2vec/src/utils.rs`](diffhunk://#diff-155285a0bd35d816f33d8bee80a64827236d8624f2cf4b81826af93d28fe6842L96-R103): Modified the `is_unordered` function to return `true` immediately when an unordered element is found, and `false` otherwise. This change eliminates the need for the `unordered` variable and reduces the number of iterations in some cases.

## Related Issues

Closes #37 