### PR TITLE
test: Add benchmarking suite for rust bindings

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -28,7 +28,7 @@ jobs:
           environments: ${{ matrix.python-environment }}
       - run: pixi run -e ${{ matrix.python-environment }} test
   benchmarks:
-    name: Python Benchmarks
+    name: Python benchmarks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,4 +36,3 @@ jobs:
         with:
           environments: py-phylo2vec
       - run: pixi run -e py-phylo2vec benchmark
-

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -27,3 +27,13 @@ jobs:
         with:
           environments: ${{ matrix.python-environment }}
       - run: pixi run -e ${{ matrix.python-environment }} test
+  benchmarks:
+    name: Python Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          environments: py-phylo2vec
+      - run: pixi run -e py-phylo2vec benchmark
+

--- a/pixi.lock
+++ b/pixi.lock
@@ -385,6 +385,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.0-py310ha75aee5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.24.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pybtex-docutils-1.0.3-py310hff52083_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
@@ -392,6 +393,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.0-h543edf9_3_cpython.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
@@ -615,6 +617,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.0-py310hb9d19b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.24.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pybtex-docutils-1.0.3-py310h2ec42d9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
@@ -624,6 +627,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py310h1c7075f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.0-h38b4d05_3_cpython.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
@@ -852,6 +856,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.0-py310hf9df320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.24.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pybtex-docutils-1.0.3-py310hbe9552e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
@@ -861,6 +866,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py310hb3dec1a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.0-h43b31ca_3_cpython.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
@@ -1003,8 +1009,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.15-h4a871b0_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-5_cp310.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py310ha75aee5_1.conda
@@ -1086,8 +1094,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.15-hd8744da_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-5_cp310.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py310h837254d_1.conda
@@ -1175,8 +1185,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.15-hdce6c4c_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-5_cp310.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py310h493c2e1_1.conda
@@ -1268,8 +1280,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
@@ -1352,8 +1366,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-ha513fb2_3_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
@@ -1442,8 +1458,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-hc51fdd5_3_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
@@ -1535,8 +1553,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
@@ -1619,8 +1639,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.7-h8f8b54e_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py312hb553811_1.conda
@@ -1709,8 +1731,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h024a12e_1.conda
@@ -2459,6 +2483,7 @@ packages:
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
+  purls: []
   size: 2562
   timestamp: 1578324546067
 - kind: conda
@@ -2477,6 +2502,7 @@ packages:
   - openmp_impl 9999
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 23621
   timestamp: 1650670423406
 - kind: conda
@@ -2490,6 +2516,7 @@ packages:
   sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
   md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
   license: BSD
+  purls: []
   size: 3566
   timestamp: 1562343890778
 - kind: conda
@@ -2506,6 +2533,8 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/accessible-pygments?source=hash-mapping
   size: 1328908
   timestamp: 1718718120070
 - kind: conda
@@ -2521,6 +2550,8 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/alabaster?source=hash-mapping
   size: 18365
   timestamp: 1704848898483
 - kind: conda
@@ -2543,6 +2574,8 @@ packages:
   - trio >=0.26.1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/anyio?source=hash-mapping
   size: 109864
   timestamp: 1728935803440
 - kind: conda
@@ -2558,6 +2591,8 @@ packages:
   - python >=3.7
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/appnope?source=hash-mapping
   size: 10241
   timestamp: 1707233195627
 - kind: conda
@@ -2577,6 +2612,8 @@ packages:
   - argon2_cffi ==999
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/argon2-cffi?source=hash-mapping
   size: 18602
   timestamp: 1692818472638
 - kind: conda
@@ -2596,6 +2633,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/argon2-cffi-bindings?source=hash-mapping
   size: 32379
   timestamp: 1725356978614
 - kind: conda
@@ -2614,6 +2653,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/argon2-cffi-bindings?source=hash-mapping
   size: 31413
   timestamp: 1725356783377
 - kind: conda
@@ -2633,6 +2674,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/argon2-cffi-bindings?source=hash-mapping
   size: 34425
   timestamp: 1725356664523
 - kind: conda
@@ -2650,6 +2693,8 @@ packages:
   - types-python-dateutil >=2.8.10
   license: Apache-2.0
   license_family: Apache
+  purls:
+  - pkg:pypi/arrow?source=hash-mapping
   size: 100096
   timestamp: 1696129131844
 - kind: conda
@@ -2666,6 +2711,8 @@ packages:
   - six >=1.12.0
   license: Apache-2.0
   license_family: Apache
+  purls:
+  - pkg:pypi/asttokens?source=hash-mapping
   size: 28922
   timestamp: 1698341257884
 - kind: conda
@@ -2682,6 +2729,8 @@ packages:
   - typing_extensions >=4.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/async-lru?source=hash-mapping
   size: 15342
   timestamp: 1690563152778
 - kind: conda
@@ -2697,6 +2746,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/attrs?source=hash-mapping
   size: 56048
   timestamp: 1722977241383
 - kind: conda
@@ -2713,6 +2764,8 @@ packages:
   - pytz >=2015.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/babel?source=hash-mapping
   size: 6525614
   timestamp: 1730878929589
 - kind: conda
@@ -2729,6 +2782,8 @@ packages:
   - soupsieve >=1.2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/beautifulsoup4?source=hash-mapping
   size: 118200
   timestamp: 1705564819537
 - kind: conda
@@ -2744,6 +2799,7 @@ packages:
   - binutils_impl_linux-64 >=2.43,<2.44.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 34178
   timestamp: 1727304728246
 - kind: conda
@@ -2759,6 +2815,7 @@ packages:
   - binutils_impl_linux-64 >=2.43,<2.44.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 33876
   timestamp: 1729655402186
 - kind: conda
@@ -2775,6 +2832,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 6233238
   timestamp: 1727304698672
 - kind: conda
@@ -2791,6 +2849,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 5682777
   timestamp: 1729655371045
 - kind: conda
@@ -2806,6 +2865,7 @@ packages:
   - binutils_impl_linux-64 2.43 h4bf12b8_1
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 34906
   timestamp: 1727304732860
 - kind: conda
@@ -2821,6 +2881,7 @@ packages:
   - binutils_impl_linux-64 2.43 h4bf12b8_2
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 34945
   timestamp: 1729655404893
 - kind: conda
@@ -2837,6 +2898,8 @@ packages:
   - webencodings
   license: Apache-2.0 AND MIT
   license_family: Apache
+  purls:
+  - pkg:pypi/bleach?source=hash-mapping
   size: 132652
   timestamp: 1730286301829
 - kind: conda
@@ -2857,6 +2920,8 @@ packages:
   - libbrotlicommon 1.1.0 h00291cd_2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
   size: 362793
   timestamp: 1725268121746
 - kind: conda
@@ -2878,6 +2943,8 @@ packages:
   - libbrotlicommon 1.1.0 hd74edd7_2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
   size: 339329
   timestamp: 1725268335778
 - kind: conda
@@ -2899,6 +2966,8 @@ packages:
   - libbrotlicommon 1.1.0 hb9d3cd8_2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
   size: 349668
   timestamp: 1725267875087
 - kind: conda
@@ -2914,6 +2983,7 @@ packages:
   - tk
   license: Tcl/Tk
   license_family: BSD
+  purls: []
   size: 122272
   timestamp: 1634380233265
 - kind: conda
@@ -2929,6 +2999,7 @@ packages:
   - tk
   license: Tcl/Tk
   license_family: BSD
+  purls: []
   size: 122487
   timestamp: 1634380112870
 - kind: conda
@@ -2944,6 +3015,7 @@ packages:
   - tk
   license: Tcl/Tk
   license_family: BSD
+  purls: []
   size: 122365
   timestamp: 1634380164061
 - kind: conda
@@ -2960,6 +3032,7 @@ packages:
   - libgcc-ng >=12
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 252783
   timestamp: 1720974456583
 - kind: conda
@@ -2975,6 +3048,7 @@ packages:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 122909
   timestamp: 1720974522888
 - kind: conda
@@ -2990,6 +3064,7 @@ packages:
   - __osx >=10.13
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 134188
   timestamp: 1720974491916
 - kind: conda
@@ -3004,6 +3079,7 @@ packages:
   - __osx >=10.13
   license: MIT
   license_family: MIT
+  purls: []
   size: 182342
   timestamp: 1729006698430
 - kind: conda
@@ -3018,6 +3094,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 177487
   timestamp: 1729006763496
 - kind: conda
@@ -3033,6 +3110,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 205797
   timestamp: 1729006575652
 - kind: conda
@@ -3051,6 +3129,7 @@ packages:
   - llvm-openmp
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6396
   timestamp: 1714575615177
 - kind: conda
@@ -3069,6 +3148,7 @@ packages:
   - llvm-openmp
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6411
   timestamp: 1714575604618
 - kind: conda
@@ -3086,6 +3166,7 @@ packages:
   - gcc_linux-64 12.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6324
   timestamp: 1714575511013
 - kind: conda
@@ -3097,6 +3178,7 @@ packages:
   sha256: 593f302d0f44c2c771e1614ee6d56fffdc7d616e6f187669c8b0e34ffce3e1ae
   md5: b7e5424e7f06547a903d28e4651dbb21
   license: ISC
+  purls: []
   size: 158665
   timestamp: 1725019059295
 - kind: conda
@@ -3108,6 +3190,7 @@ packages:
   sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
   md5: c27d1c142233b5bc9ca570c6e2e0c244
   license: ISC
+  purls: []
   size: 159003
   timestamp: 1725018903918
 - kind: conda
@@ -3119,6 +3202,7 @@ packages:
   sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
   md5: 40dec13fd8348dbe303e57be74bd3d35
   license: ISC
+  purls: []
   size: 158482
   timestamp: 1725019034582
 - kind: conda
@@ -3130,6 +3214,7 @@ packages:
   sha256: ddaafdcd1b8ace6ffeea22b6824ca9db8a64cf0a2652a11d7554ece54935fa06
   md5: b7b887091c99ed2e74845e75e9128410
   license: ISC
+  purls: []
   size: 156925
   timestamp: 1734208413176
 - kind: conda
@@ -3141,6 +3226,7 @@ packages:
   sha256: 1afd7274cbc9a334d6d0bc62fa760acc7afdaceb0b91a8df370ec01fd75dc7dd
   md5: 720523eb0d6a9b0f6120c16b2aa4e7de
   license: ISC
+  purls: []
   size: 157088
   timestamp: 1734208393264
 - kind: conda
@@ -3152,6 +3238,7 @@ packages:
   sha256: 256be633fd0882ccc1a7a32bc278547e1703f85082c0789a87a603ee3ab8fb82
   md5: 7cb381a6783d91902638e4ed1ebd478e
   license: ISC
+  purls: []
   size: 157091
   timestamp: 1734208344343
 - kind: conda
@@ -3168,6 +3255,7 @@ packages:
   - cached_property >=1.5.2,<1.5.3.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 4134
   timestamp: 1615209571450
 - kind: conda
@@ -3184,6 +3272,8 @@ packages:
   - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/cached-property?source=hash-mapping
   size: 11065
   timestamp: 1615209567874
 - kind: conda
@@ -3208,6 +3298,7 @@ packages:
   - pixman >=0.43.4,<1.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
+  purls: []
   size: 892544
   timestamp: 1721139116538
 - kind: conda
@@ -3232,6 +3323,7 @@ packages:
   - pixman >=0.43.4,<1.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
+  purls: []
   size: 899126
   timestamp: 1721139203735
 - kind: conda
@@ -3263,6 +3355,7 @@ packages:
   - xorg-libxrender >=0.9.11,<0.10.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
+  purls: []
   size: 983604
   timestamp: 1721138900054
 - kind: conda
@@ -3280,6 +3373,7 @@ packages:
   - libllvm16 >=16.0.6,<16.1.0a0
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 21588
   timestamp: 1726771695380
 - kind: conda
@@ -3297,6 +3391,7 @@ packages:
   - libllvm16 >=16.0.6,<16.1.0a0
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 21621
   timestamp: 1726771337947
 - kind: conda
@@ -3322,6 +3417,7 @@ packages:
   - clang 16.0.*
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 1099432
   timestamp: 1726771664399
 - kind: conda
@@ -3347,6 +3443,7 @@ packages:
   - clang 16.0.*
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 1091944
   timestamp: 1726771303834
 - kind: conda
@@ -3361,6 +3458,8 @@ packages:
   depends:
   - python >=3.7
   license: ISC
+  purls:
+  - pkg:pypi/certifi?source=hash-mapping
   size: 163752
   timestamp: 1725278204397
 - kind: conda
@@ -3380,6 +3479,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 229224
   timestamp: 1725560797724
 - kind: conda
@@ -3399,6 +3500,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 243532
   timestamp: 1725560630552
 - kind: conda
@@ -3417,6 +3520,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 229844
   timestamp: 1725560765436
 - kind: conda
@@ -3435,6 +3540,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 288762
   timestamp: 1725560945833
 - kind: conda
@@ -3454,6 +3561,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 288211
   timestamp: 1725560745212
 - kind: conda
@@ -3473,6 +3582,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 302115
   timestamp: 1725560701719
 - kind: conda
@@ -3492,6 +3603,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 294403
   timestamp: 1725560714366
 - kind: conda
@@ -3511,6 +3624,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 281206
   timestamp: 1725560813378
 - kind: conda
@@ -3529,6 +3644,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 282425
   timestamp: 1725560725144
 - kind: conda
@@ -3547,6 +3664,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 284540
   timestamp: 1725560667915
 - kind: conda
@@ -3566,6 +3685,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 282115
   timestamp: 1725560759157
 - kind: conda
@@ -3585,6 +3706,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
   size: 295514
   timestamp: 1725560706794
 - kind: conda
@@ -3600,6 +3723,8 @@ packages:
   - python >=3.6.1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cfgv?source=hash-mapping
   size: 10788
   timestamp: 1629909423398
 - kind: conda
@@ -3616,6 +3741,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cfgv?source=hash-mapping
   size: 12973
   timestamp: 1734267180483
 - kind: conda
@@ -3631,6 +3758,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 47314
   timestamp: 1728479405343
 - kind: conda
@@ -3651,6 +3780,7 @@ packages:
   - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 85084
   timestamp: 1725062391082
 - kind: conda
@@ -3671,6 +3801,7 @@ packages:
   - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 85224
   timestamp: 1725061905929
 - kind: conda
@@ -3694,6 +3825,7 @@ packages:
   - llvmdev 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 85001
   timestamp: 1725065170877
 - kind: conda
@@ -3717,6 +3849,7 @@ packages:
   - clang-tools 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 758625
   timestamp: 1725062311061
 - kind: conda
@@ -3740,6 +3873,7 @@ packages:
   - llvm-tools 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 758497
   timestamp: 1725061821141
 - kind: conda
@@ -3764,6 +3898,7 @@ packages:
   - llvm-tools 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 772977
   timestamp: 1725065101343
 - kind: conda
@@ -3783,6 +3918,7 @@ packages:
   - llvm-tools 16.0.6.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 17589
   timestamp: 1723069343993
 - kind: conda
@@ -3802,6 +3938,7 @@ packages:
   - llvm-tools 16.0.6.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 17659
   timestamp: 1723069383236
 - kind: conda
@@ -3817,6 +3954,7 @@ packages:
   - clang_impl_osx-64 16.0.6 h8787910_19
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 20580
   timestamp: 1723069348997
 - kind: conda
@@ -3832,6 +3970,7 @@ packages:
   - clang_impl_osx-arm64 16.0.6 hc421ffc_19
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 20589
   timestamp: 1723069388608
 - kind: conda
@@ -3850,6 +3989,7 @@ packages:
   - libcxx-devel 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 85265
   timestamp: 1725062403776
 - kind: conda
@@ -3868,6 +4008,7 @@ packages:
   - libcxx-devel 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 85293
   timestamp: 1725061917963
 - kind: conda
@@ -3886,6 +4027,7 @@ packages:
   - libllvm16 >=16.0.6,<16.1.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 17642
   timestamp: 1723069387016
 - kind: conda
@@ -3904,6 +4046,7 @@ packages:
   - libllvm16 >=16.0.6,<16.1.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 17740
   timestamp: 1723069417515
 - kind: conda
@@ -3920,6 +4063,7 @@ packages:
   - clangxx_impl_osx-64 16.0.6 h6d92fbe_19
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 19289
   timestamp: 1723069392162
 - kind: conda
@@ -3936,6 +4080,7 @@ packages:
   - clangxx_impl_osx-arm64 16.0.6 hcd7bac0_19
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 19366
   timestamp: 1723069423746
 - kind: conda
@@ -3953,6 +4098,8 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/click?source=hash-mapping
   size: 84513
   timestamp: 1733221925078
 - kind: conda
@@ -3969,6 +4116,8 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
 - kind: conda
@@ -3985,6 +4134,8 @@ packages:
   - traitlets >=5.3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/comm?source=hash-mapping
   size: 12134
   timestamp: 1710320435158
 - kind: conda
@@ -4002,6 +4153,7 @@ packages:
   - compiler-rt_osx-arm64 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 93724
   timestamp: 1701467327657
 - kind: conda
@@ -4019,6 +4171,7 @@ packages:
   - compiler-rt_osx-64 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 94198
   timestamp: 1701467261175
 - kind: conda
@@ -4038,6 +4191,7 @@ packages:
   - compiler-rt 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 9895261
   timestamp: 1701467223753
 - kind: conda
@@ -4057,6 +4211,7 @@ packages:
   - compiler-rt 16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 9829914
   timestamp: 1701467293179
 - kind: conda
@@ -4074,6 +4229,7 @@ packages:
   - fortran-compiler 1.7.0 h6c2ab21_1
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 7237
   timestamp: 1714575625198
 - kind: conda
@@ -4091,6 +4247,7 @@ packages:
   - fortran-compiler 1.7.0 heb67821_1
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 7129
   timestamp: 1714575517071
 - kind: conda
@@ -4108,6 +4265,7 @@ packages:
   - fortran-compiler 1.7.0 hafb19e3_1
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 7261
   timestamp: 1714575637236
 - kind: conda
@@ -4128,6 +4286,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 157383
   timestamp: 1726660054429
 - kind: conda
@@ -4148,6 +4307,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 159638
   timestamp: 1726660283789
 - kind: conda
@@ -4169,6 +4329,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 173268
   timestamp: 1726659802291
 - kind: conda
@@ -4186,6 +4347,7 @@ packages:
   - gxx_linux-64 12.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6283
   timestamp: 1714575513327
 - kind: conda
@@ -4202,6 +4364,7 @@ packages:
   - clangxx_osx-arm64 16.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6442
   timestamp: 1714575634473
 - kind: conda
@@ -4218,6 +4381,7 @@ packages:
   - clangxx_osx-64 16.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6394
   timestamp: 1714575621870
 - kind: conda
@@ -4235,6 +4399,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/debugpy?source=hash-mapping
   size: 2055174
   timestamp: 1731045112027
 - kind: conda
@@ -4253,6 +4419,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/debugpy?source=hash-mapping
   size: 2092262
   timestamp: 1731045180185
 - kind: conda
@@ -4271,6 +4439,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/debugpy?source=hash-mapping
   size: 2140733
   timestamp: 1731045018424
 - kind: conda
@@ -4286,6 +4456,8 @@ packages:
   - python >=3.5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/decorator?source=hash-mapping
   size: 12072
   timestamp: 1641555714315
 - kind: conda
@@ -4301,6 +4473,8 @@ packages:
   - python >=3.6
   license: PSF-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/defusedxml?source=hash-mapping
   size: 24062
   timestamp: 1615232388757
 - kind: conda
@@ -4317,6 +4491,8 @@ packages:
   - python >=3.9
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/distlib?source=hash-mapping
   size: 274151
   timestamp: 1733238487461
 - kind: conda
@@ -4332,6 +4508,8 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  purls:
+  - pkg:pypi/docutils?source=hash-mapping
   size: 726058
   timestamp: 1701883025895
 - kind: conda
@@ -4348,6 +4526,8 @@ packages:
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
   license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  purls:
+  - pkg:pypi/docutils?source=hash-mapping
   size: 724382
   timestamp: 1701883129364
 - kind: conda
@@ -4363,6 +4543,8 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  purls:
+  - pkg:pypi/docutils?source=hash-mapping
   size: 721381
   timestamp: 1701882768459
 - kind: conda
@@ -4378,6 +4560,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/entrypoints?source=hash-mapping
   size: 9199
   timestamp: 1643888357950
 - kind: conda
@@ -4392,6 +4576,8 @@ packages:
   depends:
   - python >=3.7
   license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 20418
   timestamp: 1720869435725
 - kind: conda
@@ -4407,6 +4593,8 @@ packages:
   depends:
   - python >=3.9
   license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 20486
   timestamp: 1733208916977
 - kind: conda
@@ -4422,6 +4610,8 @@ packages:
   - python >=2.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/executing?source=hash-mapping
   size: 28337
   timestamp: 1725214501850
 - kind: conda
@@ -4437,6 +4627,8 @@ packages:
   depends:
   - python >=3.9
   license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=hash-mapping
   size: 17441
   timestamp: 1733240909987
 - kind: conda
@@ -4450,6 +4642,7 @@ packages:
   md5: 0c96522c6bdaed4b1566d11387caaf45
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 397370
   timestamp: 1566932522327
 - kind: conda
@@ -4463,6 +4656,7 @@ packages:
   md5: 34893075a5c9e55cdafac56607368fc6
   license: OFL-1.1
   license_family: Other
+  purls: []
   size: 96530
   timestamp: 1620479909603
 - kind: conda
@@ -4476,6 +4670,7 @@ packages:
   md5: 4d59c254e01d9cde7957100457e2d5fb
   license: OFL-1.1
   license_family: Other
+  purls: []
   size: 700814
   timestamp: 1620479612257
 - kind: conda
@@ -4490,6 +4685,7 @@ packages:
   md5: 49023d73832ef61042f6a237cb2687e7
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
+  purls: []
   size: 1620504
   timestamp: 1727511233259
 - kind: conda
@@ -4507,6 +4703,7 @@ packages:
   - libexpat >=2.6.3,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   license: MIT
+  purls: []
   size: 234227
   timestamp: 1730284037572
 - kind: conda
@@ -4524,6 +4721,7 @@ packages:
   - libexpat >=2.6.3,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   license: MIT
+  purls: []
   size: 232313
   timestamp: 1730283983397
 - kind: conda
@@ -4543,6 +4741,7 @@ packages:
   - libuuid >=2.38.1,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   license: MIT
+  purls: []
   size: 265599
   timestamp: 1730283881107
 - kind: conda
@@ -4558,6 +4757,7 @@ packages:
   - fonts-conda-forge
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 3667
   timestamp: 1566974674465
 - kind: conda
@@ -4576,6 +4776,7 @@ packages:
   - font-ttf-ubuntu
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 4102
   timestamp: 1566932280397
 - kind: conda
@@ -4595,6 +4796,7 @@ packages:
   - llvm-openmp
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6405
   timestamp: 1714575618546
 - kind: conda
@@ -4614,6 +4816,7 @@ packages:
   - llvm-openmp
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6480
   timestamp: 1714575630136
 - kind: conda
@@ -4632,6 +4835,7 @@ packages:
   - gfortran_linux-64 12.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6300
   timestamp: 1714575515211
 - kind: conda
@@ -4648,6 +4852,8 @@ packages:
   - python >=2.7,<4
   license: MPL-2.0
   license_family: MOZILLA
+  purls:
+  - pkg:pypi/fqdn?source=hash-mapping
   size: 14395
   timestamp: 1638810388635
 - kind: conda
@@ -4664,6 +4870,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
+  purls: []
   size: 634972
   timestamp: 1694615932610
 - kind: conda
@@ -4679,6 +4886,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
+  purls: []
   size: 599300
   timestamp: 1694616137838
 - kind: conda
@@ -4694,6 +4902,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
+  purls: []
   size: 596430
   timestamp: 1694616332835
 - kind: conda
@@ -4705,6 +4914,7 @@ packages:
   sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
   md5: c64443234ff91d70cb9c7dc926c58834
   license: LGPL-2.1
+  purls: []
   size: 60255
   timestamp: 1604417405528
 - kind: conda
@@ -4718,6 +4928,7 @@ packages:
   depends:
   - libgcc-ng >=7.5.0
   license: LGPL-2.1
+  purls: []
   size: 114383
   timestamp: 1604416621168
 - kind: conda
@@ -4729,6 +4940,7 @@ packages:
   sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
   md5: f1c6b41e0f56998ecd9a3e210faa1dc0
   license: LGPL-2.1
+  purls: []
   size: 65388
   timestamp: 1604417213
 - kind: conda
@@ -4744,6 +4956,7 @@ packages:
   - gcc_impl_linux-64 12.4.0.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 53770
   timestamp: 1724802037449
 - kind: conda
@@ -4765,6 +4978,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 62030150
   timestamp: 1724801895487
 - kind: conda
@@ -4782,6 +4996,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 31943
   timestamp: 1727281489360
 - kind: conda
@@ -4799,6 +5014,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 31891
   timestamp: 1729281921785
 - kind: conda
@@ -4816,6 +5032,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 32033
   timestamp: 1731939586925
 - kind: conda
@@ -4833,6 +5050,7 @@ packages:
   - ld64
   license: GPL-3.0-or-later WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 31942
   timestamp: 1692106730571
 - kind: conda
@@ -4850,6 +5068,7 @@ packages:
   - ld64
   license: GPL-3.0-or-later WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 31910
   timestamp: 1692106711872
 - kind: conda
@@ -4867,6 +5086,7 @@ packages:
   - gfortran_impl_linux-64 12.4.0.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 53201
   timestamp: 1724802175387
 - kind: conda
@@ -4886,6 +5106,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 15424743
   timestamp: 1724802095460
 - kind: conda
@@ -4910,6 +5131,7 @@ packages:
   - zlib
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 20186788
   timestamp: 1707327999586
 - kind: conda
@@ -4934,6 +5156,7 @@ packages:
   - zlib
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 17385653
   timestamp: 1707329842729
 - kind: conda
@@ -4952,6 +5175,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 30340
   timestamp: 1727281503115
 - kind: conda
@@ -4970,6 +5194,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 30276
   timestamp: 1729281931321
 - kind: conda
@@ -4988,6 +5213,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 30393
   timestamp: 1731939604118
 - kind: conda
@@ -5010,6 +5236,7 @@ packages:
   - libgfortran5 >=12.3.0
   license: GPL-3.0-or-later WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 34958
   timestamp: 1692106693203
 - kind: conda
@@ -5032,6 +5259,7 @@ packages:
   - libgfortran5 >=12.3.0
   license: GPL-3.0-or-later WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 35073
   timestamp: 1692106707604
 - kind: conda
@@ -5047,6 +5275,7 @@ packages:
   - __osx >=11.0
   - libcxx >=16
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
   size: 365188
   timestamp: 1718981343258
 - kind: conda
@@ -5062,6 +5291,7 @@ packages:
   - __osx >=10.13
   - libcxx >=16
   license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
   size: 428919
   timestamp: 1718981041839
 - kind: conda
@@ -5078,6 +5308,7 @@ packages:
   - libstdcxx-ng >=12
   license: LGPL-2.0-or-later
   license_family: LGPL
+  purls: []
   size: 96855
   timestamp: 1711634169756
 - kind: conda
@@ -5093,6 +5324,7 @@ packages:
   - libcxx >=16
   license: LGPL-2.0-or-later
   license_family: LGPL
+  purls: []
   size: 84384
   timestamp: 1711634311095
 - kind: conda
@@ -5108,6 +5340,7 @@ packages:
   - libcxx >=16
   license: LGPL-2.0-or-later
   license_family: LGPL
+  purls: []
   size: 79774
   timestamp: 1711634444608
 - kind: conda
@@ -5126,6 +5359,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/greenlet?source=hash-mapping
   size: 208760
   timestamp: 1734532979629
 - kind: conda
@@ -5145,6 +5380,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/greenlet?source=hash-mapping
   size: 209577
   timestamp: 1734533147792
 - kind: conda
@@ -5164,6 +5401,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/greenlet?source=hash-mapping
   size: 214503
   timestamp: 1734532935475
 - kind: conda
@@ -5179,6 +5418,7 @@ packages:
   - libcblas >=3.9.0,<4.0a0
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 2734398
   timestamp: 1626369562748
 - kind: conda
@@ -5194,6 +5434,7 @@ packages:
   - libcblas >=3.8.0,<4.0a0
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 3221488
   timestamp: 1626369980688
 - kind: conda
@@ -5210,6 +5451,7 @@ packages:
   - libgcc-ng >=9.3.0
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 3376423
   timestamp: 1626369596591
 - kind: conda
@@ -5226,6 +5468,7 @@ packages:
   - gxx_impl_linux-64 12.4.0.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 53219
   timestamp: 1724802186786
 - kind: conda
@@ -5244,6 +5487,7 @@ packages:
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 12711904
   timestamp: 1724802140227
 - kind: conda
@@ -5262,6 +5506,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 30317
   timestamp: 1727281506580
 - kind: conda
@@ -5280,6 +5525,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 30273
   timestamp: 1729281933718
 - kind: conda
@@ -5298,6 +5544,7 @@ packages:
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 30384
   timestamp: 1731939606577
 - kind: conda
@@ -5314,6 +5561,8 @@ packages:
   - typing_extensions
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/h11?source=hash-mapping
   size: 48251
   timestamp: 1664132995560
 - kind: conda
@@ -5331,6 +5580,8 @@ packages:
   - python >=3.6.1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/h2?source=hash-mapping
   size: 46754
   timestamp: 1634280590080
 - kind: conda
@@ -5352,6 +5603,7 @@ packages:
   - libglib >=2.80.3,<3.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1372588
   timestamp: 1721186294497
 - kind: conda
@@ -5373,6 +5625,7 @@ packages:
   - libglib >=2.80.3,<3.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1317509
   timestamp: 1721186764931
 - kind: conda
@@ -5395,6 +5648,7 @@ packages:
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 1603653
   timestamp: 1721186240105
 - kind: conda
@@ -5410,6 +5664,8 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/hpack?source=hash-mapping
   size: 25341
   timestamp: 1598856368685
 - kind: conda
@@ -5430,6 +5686,8 @@ packages:
   - sniffio 1.*
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/httpcore?source=hash-mapping
   size: 45711
   timestamp: 1727821031365
 - kind: conda
@@ -5450,6 +5708,8 @@ packages:
   - sniffio
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/httpx?source=hash-mapping
   size: 65085
   timestamp: 1724778453275
 - kind: conda
@@ -5465,6 +5725,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/hyperframe?source=hash-mapping
   size: 14646
   timestamp: 1619110249723
 - kind: conda
@@ -5479,6 +5741,7 @@ packages:
   - __osx >=10.13
   license: MIT
   license_family: MIT
+  purls: []
   size: 11761697
   timestamp: 1720853679409
 - kind: conda
@@ -5495,6 +5758,7 @@ packages:
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 12129203
   timestamp: 1720853576813
 - kind: conda
@@ -5509,6 +5773,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 11857802
   timestamp: 1720853997952
 - kind: conda
@@ -5525,6 +5790,8 @@ packages:
   - ukkonen
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/identify?source=hash-mapping
   size: 78352
   timestamp: 1732589463054
 - kind: conda
@@ -5542,6 +5809,8 @@ packages:
   - ukkonen
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/identify?source=hash-mapping
   size: 78416
   timestamp: 1734206724007
 - kind: conda
@@ -5557,6 +5826,8 @@ packages:
   - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=hash-mapping
   size: 49837
   timestamp: 1726459583613
 - kind: conda
@@ -5572,6 +5843,8 @@ packages:
   - python >=3.4
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/imagesize?source=hash-mapping
   size: 10164
   timestamp: 1656939625410
 - kind: conda
@@ -5588,6 +5861,8 @@ packages:
   - zipp >=0.5
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-metadata?source=hash-mapping
   size: 28646
   timestamp: 1726082927916
 - kind: conda
@@ -5604,6 +5879,7 @@ packages:
   - importlib-metadata >=8.5.0,<8.5.1.0a0
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 9362
   timestamp: 1733223207817
 - kind: conda
@@ -5622,6 +5898,8 @@ packages:
   - importlib-resources >=6.4.5,<6.4.6.0a0
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-resources?source=hash-mapping
   size: 32725
   timestamp: 1725921462405
 - kind: conda
@@ -5638,6 +5916,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/iniconfig?source=hash-mapping
   size: 11474
   timestamp: 1733223232820
 - kind: conda
@@ -5666,6 +5946,8 @@ packages:
   - traitlets >=5.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/ipykernel?source=hash-mapping
   size: 119084
   timestamp: 1719845605084
 - kind: conda
@@ -5695,6 +5977,8 @@ packages:
   - traitlets >=5.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/ipykernel?source=hash-mapping
   size: 119568
   timestamp: 1719845667420
 - kind: conda
@@ -5722,6 +6006,8 @@ packages:
   - typing_extensions >=4.6
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/ipython?source=hash-mapping
   size: 599356
   timestamp: 1729866495921
 - kind: conda
@@ -5739,6 +6025,7 @@ packages:
   - isl_imath-32
   license: MIT
   license_family: MIT
+  purls: []
   size: 894410
   timestamp: 1680649639107
 - kind: conda
@@ -5756,6 +6043,7 @@ packages:
   - isl_imath-32
   license: MIT
   license_family: MIT
+  purls: []
   size: 819937
   timestamp: 1680649567633
 - kind: conda
@@ -5772,6 +6060,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/isoduration?source=hash-mapping
   size: 17189
   timestamp: 1638811664194
 - kind: conda
@@ -5788,6 +6078,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/jedi?source=hash-mapping
   size: 841312
   timestamp: 1696326218364
 - kind: conda
@@ -5804,6 +6096,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jinja2?source=hash-mapping
   size: 111565
   timestamp: 1715127275924
 - kind: conda
@@ -5819,6 +6113,8 @@ packages:
   - python >=3.7,<4.0
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/json5?source=hash-mapping
   size: 27995
   timestamp: 1712986338874
 - kind: conda
@@ -5835,6 +6131,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jsonpointer?source=hash-mapping
   size: 15789
   timestamp: 1725303070637
 - kind: conda
@@ -5852,6 +6150,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jsonpointer?source=hash-mapping
   size: 16203
   timestamp: 1725303244939
 - kind: conda
@@ -5868,6 +6168,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jsonpointer?source=hash-mapping
   size: 15658
   timestamp: 1725302992487
 - kind: conda
@@ -5889,6 +6191,8 @@ packages:
   - rpds-py >=0.7.1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/jsonschema?source=hash-mapping
   size: 74323
   timestamp: 1720529611305
 - kind: conda
@@ -5905,6 +6209,8 @@ packages:
   - referencing >=0.31.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/jsonschema-specifications?source=hash-mapping
   size: 16165
   timestamp: 1728418976382
 - kind: conda
@@ -5928,6 +6234,7 @@ packages:
   - webcolors >=24.6.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 7143
   timestamp: 1720529619500
 - kind: conda
@@ -5962,6 +6269,8 @@ packages:
   - sphinxcontrib-bibtex >=2.5.0,<3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyter-book?source=hash-mapping
   size: 44821
   timestamp: 1728353507963
 - kind: conda
@@ -5985,6 +6294,8 @@ packages:
   - tabulate
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/jupyter-cache?source=hash-mapping
   size: 31236
   timestamp: 1731777189586
 - kind: conda
@@ -6002,6 +6313,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyter-lsp?source=hash-mapping
   size: 55539
   timestamp: 1712707521811
 - kind: conda
@@ -6023,6 +6336,8 @@ packages:
   - traitlets >=5.3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyter-client?source=hash-mapping
   size: 106055
   timestamp: 1726610805505
 - kind: conda
@@ -6042,6 +6357,8 @@ packages:
   - traitlets >=5.3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyter-core?source=hash-mapping
   size: 57671
   timestamp: 1727163547058
 - kind: conda
@@ -6064,6 +6381,8 @@ packages:
   - traitlets >=5.3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyter-events?source=hash-mapping
   size: 21475
   timestamp: 1710805759187
 - kind: conda
@@ -6097,6 +6416,8 @@ packages:
   - websocket-client >=1.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyter-server?source=hash-mapping
   size: 323978
   timestamp: 1720816754998
 - kind: conda
@@ -6113,6 +6434,8 @@ packages:
   - terminado >=0.8.3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyter-server-terminals?source=hash-mapping
   size: 19818
   timestamp: 1710262791393
 - kind: conda
@@ -6143,6 +6466,8 @@ packages:
   - traitlets
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyterlab?source=hash-mapping
   size: 7623856
   timestamp: 1714169414542
 - kind: conda
@@ -6162,6 +6487,8 @@ packages:
   - jupyterlab >=4.0.8,<5.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyterlab-pygments?source=hash-mapping
   size: 18776
   timestamp: 1707149279640
 - kind: conda
@@ -6187,6 +6514,8 @@ packages:
   - openapi-core >=0.18.0,<0.19.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jupyterlab-server?source=hash-mapping
   size: 49355
   timestamp: 1721163412436
 - kind: conda
@@ -6203,6 +6532,7 @@ packages:
   - sysroot_linux-64 ==2.17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 945088
   timestamp: 1727437651716
 - kind: conda
@@ -6219,6 +6549,7 @@ packages:
   - sysroot_linux-64 ==2.17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 943486
   timestamp: 1729794504440
 - kind: conda
@@ -6232,6 +6563,7 @@ packages:
   depends:
   - libgcc-ng >=10.3.0
   license: LGPL-2.1-or-later
+  purls: []
   size: 117831
   timestamp: 1646151697040
 - kind: conda
@@ -6250,6 +6582,7 @@ packages:
   - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1155530
   timestamp: 1719463474401
 - kind: conda
@@ -6268,6 +6601,7 @@ packages:
   - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1185323
   timestamp: 1719463492984
 - kind: conda
@@ -6287,6 +6621,7 @@ packages:
   - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1370023
   timestamp: 1719463201255
 - kind: conda
@@ -6303,6 +6638,8 @@ packages:
   - six
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/latexcodec?source=hash-mapping
   size: 18212
   timestamp: 1592937373647
 - kind: conda
@@ -6322,6 +6659,7 @@ packages:
   - cctools 1010.6.*
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 18928
   timestamp: 1726771322773
 - kind: conda
@@ -6341,6 +6679,7 @@ packages:
   - cctools_osx-64 1010.6.*
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 18850
   timestamp: 1726771680769
 - kind: conda
@@ -6365,6 +6704,7 @@ packages:
   - ld 951.9.*
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 1088101
   timestamp: 1726771578888
 - kind: conda
@@ -6389,6 +6729,7 @@ packages:
   - cctools 1010.6.*
   license: APSL-2.0
   license_family: Other
+  purls: []
   size: 1006497
   timestamp: 1726771248963
 - kind: conda
@@ -6406,6 +6747,7 @@ packages:
   - binutils_impl_linux-64 2.43
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 669616
   timestamp: 1727304687962
 - kind: conda
@@ -6423,6 +6765,7 @@ packages:
   - binutils_impl_linux-64 2.43
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 669211
   timestamp: 1729655358674
 - kind: conda
@@ -6438,6 +6781,7 @@ packages:
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 281798
   timestamp: 1657977462600
 - kind: conda
@@ -6452,6 +6796,7 @@ packages:
   - libcxx >=13.0.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 215721
   timestamp: 1657977558796
 - kind: conda
@@ -6466,6 +6811,7 @@ packages:
   - libcxx >=13.0.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 290319
   timestamp: 1657977526749
 - kind: conda
@@ -6481,6 +6827,7 @@ packages:
   - __osx >=11.0
   - libcxx >=16
   license: LGPL-2.1-or-later
+  purls: []
   size: 40657
   timestamp: 1723626937704
 - kind: conda
@@ -6496,6 +6843,7 @@ packages:
   - __osx >=10.13
   - libcxx >=16
   license: LGPL-2.1-or-later
+  purls: []
   size: 40442
   timestamp: 1723626787726
 - kind: conda
@@ -6517,6 +6865,7 @@ packages:
   - liblapacke 3.9.0 25_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15677
   timestamp: 1729642900350
 - kind: conda
@@ -6538,6 +6887,7 @@ packages:
   - libcblas 3.9.0 25_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15952
   timestamp: 1729643159199
 - kind: conda
@@ -6559,6 +6909,7 @@ packages:
   - libcblas 3.9.0 25_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15913
   timestamp: 1729643265495
 - kind: conda
@@ -6578,6 +6929,7 @@ packages:
   - liblapacke 3.9.0 25_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15613
   timestamp: 1729642905619
 - kind: conda
@@ -6597,6 +6949,7 @@ packages:
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15842
   timestamp: 1729643166929
 - kind: conda
@@ -6616,6 +6969,7 @@ packages:
   - liblapacke 3.9.0 25_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15837
   timestamp: 1729643270793
 - kind: conda
@@ -6633,6 +6987,7 @@ packages:
   - libllvm16 >=16.0.6,<16.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 12823030
   timestamp: 1725061894194
 - kind: conda
@@ -6650,6 +7005,7 @@ packages:
   - libllvm16 >=16.0.6,<16.1.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 11873230
   timestamp: 1725061438744
 - kind: conda
@@ -6668,6 +7024,7 @@ packages:
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 18089799
   timestamp: 1725064996473
 - kind: conda
@@ -6688,6 +7045,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 379948
   timestamp: 1726660033582
 - kind: conda
@@ -6708,6 +7066,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 402588
   timestamp: 1726660264675
 - kind: conda
@@ -6729,6 +7088,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 424900
   timestamp: 1726659794676
 - kind: conda
@@ -6743,6 +7103,7 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 521199
   timestamp: 1729038190391
 - kind: conda
@@ -6757,6 +7118,7 @@ packages:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 526600
   timestamp: 1729038055775
 - kind: conda
@@ -6771,6 +7133,7 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 520771
   timestamp: 1730314603920
 - kind: conda
@@ -6785,6 +7148,7 @@ packages:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 528991
   timestamp: 1730314340106
 - kind: conda
@@ -6800,6 +7164,7 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 520992
   timestamp: 1734494699681
 - kind: conda
@@ -6815,6 +7180,7 @@ packages:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 527370
   timestamp: 1734494305140
 - kind: conda
@@ -6830,6 +7196,7 @@ packages:
   - libcxx >=16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 717680
   timestamp: 1725067968232
 - kind: conda
@@ -6845,6 +7212,7 @@ packages:
   - libcxx >=16.0.6
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 716532
   timestamp: 1725067685814
 - kind: conda
@@ -6859,6 +7227,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 54533
   timestamp: 1722820240854
 - kind: conda
@@ -6873,6 +7242,7 @@ packages:
   - __osx >=10.13
   license: MIT
   license_family: MIT
+  purls: []
   size: 70570
   timestamp: 1722820232914
 - kind: conda
@@ -6888,6 +7258,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 72242
   timestamp: 1728177071251
 - kind: conda
@@ -6903,6 +7274,7 @@ packages:
   - ncurses >=6.2,<7.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 105382
   timestamp: 1597616576726
 - kind: conda
@@ -6918,6 +7290,7 @@ packages:
   - ncurses >=6.2,<7.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 96607
   timestamp: 1597616630749
 - kind: conda
@@ -6934,6 +7307,7 @@ packages:
   - ncurses >=6.2,<7.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 123878
   timestamp: 1597616541093
 - kind: conda
@@ -6947,6 +7321,7 @@ packages:
   md5: 899db79329439820b7e8f8de41bca902
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 106663
   timestamp: 1702146352558
 - kind: conda
@@ -6960,6 +7335,7 @@ packages:
   md5: 36d33e440c31857372a72137f78bacf5
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 107458
   timestamp: 1702146414478
 - kind: conda
@@ -6975,6 +7351,7 @@ packages:
   - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 112766
   timestamp: 1702146165126
 - kind: conda
@@ -6992,6 +7369,7 @@ packages:
   - expat 2.6.3.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 73616
   timestamp: 1725568742634
 - kind: conda
@@ -7008,6 +7386,7 @@ packages:
   - expat 2.6.3.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 70517
   timestamp: 1725568864316
 - kind: conda
@@ -7024,6 +7403,7 @@ packages:
   - expat 2.6.3.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 63895
   timestamp: 1725568783033
 - kind: conda
@@ -7040,6 +7420,7 @@ packages:
   - expat 2.6.4.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 70758
   timestamp: 1730967204736
 - kind: conda
@@ -7056,6 +7437,7 @@ packages:
   - expat 2.6.4.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 64693
   timestamp: 1730967175868
 - kind: conda
@@ -7073,6 +7455,7 @@ packages:
   - expat 2.6.4.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 73304
   timestamp: 1730967041968
 - kind: conda
@@ -7086,6 +7469,7 @@ packages:
   md5: ccb34fb14960ad8b125962d3d79b31a9
   license: MIT
   license_family: MIT
+  purls: []
   size: 51348
   timestamp: 1636488394370
 - kind: conda
@@ -7099,6 +7483,7 @@ packages:
   md5: 086914b672be056eb70fd4285b6783b6
   license: MIT
   license_family: MIT
+  purls: []
   size: 39020
   timestamp: 1636488587153
 - kind: conda
@@ -7114,6 +7499,7 @@ packages:
   - libgcc-ng >=9.4.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 58292
   timestamp: 1636488182923
 - kind: conda
@@ -7133,6 +7519,7 @@ packages:
   - libgcc-ng ==14.2.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 848745
   timestamp: 1729027721139
 - kind: conda
@@ -7149,6 +7536,7 @@ packages:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 2556252
   timestamp: 1724801659892
 - kind: conda
@@ -7164,6 +7552,7 @@ packages:
   - libgcc 14.2.0 h77fa898_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 54142
   timestamp: 1729027726517
 - kind: conda
@@ -7181,6 +7570,7 @@ packages:
   - libintl 0.22.5 h8414b35_3
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 159800
   timestamp: 1723627007035
 - kind: conda
@@ -7198,6 +7588,7 @@ packages:
   - libintl 0.22.5 hdfe23c8_3
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 172305
   timestamp: 1723626852373
 - kind: conda
@@ -7213,6 +7604,7 @@ packages:
   - libgfortran5 13.2.0 h2873a65_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 110106
   timestamp: 1707328956438
 - kind: conda
@@ -7228,6 +7620,7 @@ packages:
   - libgfortran5 13.2.0 hf226fd6_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 110233
   timestamp: 1707330749033
 - kind: conda
@@ -7245,6 +7638,7 @@ packages:
   - libgfortran-ng ==14.2.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 53997
   timestamp: 1729027752995
 - kind: conda
@@ -7259,6 +7653,7 @@ packages:
   md5: 39eeea5454333825d72202fae2d5e0b8
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 433415
   timestamp: 1707327965963
 - kind: conda
@@ -7273,6 +7668,7 @@ packages:
   md5: 0da2eb10fdfde6b4fc5cf91e0a99d29a
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 380238
   timestamp: 1707329807507
 - kind: conda
@@ -7288,6 +7684,7 @@ packages:
   - libgfortran 14.2.0 h69a702a_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 54106
   timestamp: 1729027945817
 - kind: conda
@@ -7305,6 +7702,7 @@ packages:
   - libgfortran 5.0.0 13_2_0_*_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 1571379
   timestamp: 1707328880361
 - kind: conda
@@ -7322,6 +7720,7 @@ packages:
   - libgfortran 5.0.0 13_2_0_*_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 997381
   timestamp: 1707330687590
 - kind: conda
@@ -7339,6 +7738,7 @@ packages:
   - libgfortran 14.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 1462645
   timestamp: 1729027735353
 - kind: conda
@@ -7358,6 +7758,7 @@ packages:
   - openssl >=3.3.2,<4.0a0
   - pcre2 >=10.44,<10.45.0a0
   license: GPL-2.0-only WITH GCC-exception-2.0
+  purls: []
   size: 741608
   timestamp: 1730344887972
 - kind: conda
@@ -7377,6 +7778,7 @@ packages:
   - openssl >=3.3.2,<4.0a0
   - pcre2 >=10.44,<10.45.0a0
   license: GPL-2.0-only WITH GCC-exception-2.0
+  purls: []
   size: 890358
   timestamp: 1730344741066
 - kind: conda
@@ -7396,6 +7798,7 @@ packages:
   - openssl >=3.3.2,<4.0a0
   - pcre2 >=10.44,<10.45.0a0
   license: GPL-2.0-only WITH GCC-exception-2.0
+  purls: []
   size: 768360
   timestamp: 1730344951532
 - kind: conda
@@ -7416,6 +7819,7 @@ packages:
   constrains:
   - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
+  purls: []
   size: 3635416
   timestamp: 1729191799117
 - kind: conda
@@ -7436,6 +7840,7 @@ packages:
   constrains:
   - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
+  purls: []
   size: 3931898
   timestamp: 1729191404130
 - kind: conda
@@ -7456,6 +7861,7 @@ packages:
   constrains:
   - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
+  purls: []
   size: 3692367
   timestamp: 1729191628049
 - kind: conda
@@ -7471,6 +7877,7 @@ packages:
   - _libgcc_mutex 0.1 conda_forge
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 460992
   timestamp: 1729027639220
 - kind: conda
@@ -7483,6 +7890,7 @@ packages:
   sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
   md5: 69bda57310071cf6d2b86caf11573d2d
   license: LGPL-2.1-only
+  purls: []
   size: 676469
   timestamp: 1702682458114
 - kind: conda
@@ -7497,6 +7905,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-only
+  purls: []
   size: 705775
   timestamp: 1702682170569
 - kind: conda
@@ -7509,6 +7918,7 @@ packages:
   sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
   md5: 6c3628d047e151efba7cf08c5e54d1ca
   license: LGPL-2.1-only
+  purls: []
   size: 666538
   timestamp: 1702682713201
 - kind: conda
@@ -7524,6 +7934,7 @@ packages:
   - __osx >=11.0
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 81171
   timestamp: 1723626968270
 - kind: conda
@@ -7539,6 +7950,7 @@ packages:
   - __osx >=10.13
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 88086
   timestamp: 1723626826235
 - kind: conda
@@ -7553,6 +7965,7 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
   size: 579748
   timestamp: 1694475265912
 - kind: conda
@@ -7567,6 +7980,7 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
   size: 547541
   timestamp: 1694475104253
 - kind: conda
@@ -7583,6 +7997,7 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
   size: 618575
   timestamp: 1694474974816
 - kind: conda
@@ -7602,6 +8017,7 @@ packages:
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15608
   timestamp: 1729642910812
 - kind: conda
@@ -7621,6 +8037,7 @@ packages:
   - libcblas 3.9.0 25_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15852
   timestamp: 1729643174413
 - kind: conda
@@ -7640,6 +8057,7 @@ packages:
   - libcblas 3.9.0 25_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 15823
   timestamp: 1729643275943
 - kind: conda
@@ -7658,6 +8076,7 @@ packages:
   - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 23347663
   timestamp: 1701374993634
 - kind: conda
@@ -7677,6 +8096,7 @@ packages:
   - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 35359734
   timestamp: 1701375139881
 - kind: conda
@@ -7695,6 +8115,7 @@ packages:
   - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 25196932
   timestamp: 1701379796962
 - kind: conda
@@ -7709,6 +8130,7 @@ packages:
   depends:
   - __osx >=11.0
   license: 0BSD
+  purls: []
   size: 99129
   timestamp: 1733407496073
 - kind: conda
@@ -7724,6 +8146,7 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   license: 0BSD
+  purls: []
   size: 111132
   timestamp: 1733407410083
 - kind: conda
@@ -7738,6 +8161,7 @@ packages:
   depends:
   - __osx >=10.13
   license: 0BSD
+  purls: []
   size: 103745
   timestamp: 1733407504892
 - kind: conda
@@ -7753,6 +8177,7 @@ packages:
   - __osx >=11.0
   - liblzma 5.6.3 h39f12f2_1
   license: 0BSD
+  purls: []
   size: 113099
   timestamp: 1733407511832
 - kind: conda
@@ -7769,6 +8194,7 @@ packages:
   - libgcc >=13
   - liblzma 5.6.3 hb9d3cd8_1
   license: 0BSD
+  purls: []
   size: 376794
   timestamp: 1733407421190
 - kind: conda
@@ -7784,6 +8210,7 @@ packages:
   - __osx >=10.13
   - liblzma 5.6.3 hd471939_1
   license: 0BSD
+  purls: []
   size: 113085
   timestamp: 1733407525591
 - kind: conda
@@ -7799,6 +8226,7 @@ packages:
   - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 89991
   timestamp: 1723817448345
 - kind: conda
@@ -7813,6 +8241,7 @@ packages:
   - __osx >=11.0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 69263
   timestamp: 1723817629767
 - kind: conda
@@ -7827,6 +8256,7 @@ packages:
   - __osx >=10.13
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 76561
   timestamp: 1723817691512
 - kind: conda
@@ -7848,6 +8278,7 @@ packages:
   - openssl >=3.3.2,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 647599
   timestamp: 1729571887612
 - kind: conda
@@ -7868,6 +8299,7 @@ packages:
   - openssl >=3.3.2,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 566719
   timestamp: 1729572385640
 - kind: conda
@@ -7888,6 +8320,7 @@ packages:
   - openssl >=3.3.2,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 606663
   timestamp: 1729572019083
 - kind: conda
@@ -7902,6 +8335,7 @@ packages:
   - libgcc-ng >=12
   license: LGPL-2.1-only
   license_family: GPL
+  purls: []
   size: 33408
   timestamp: 1697359010159
 - kind: conda
@@ -7921,6 +8355,7 @@ packages:
   - openblas >=0.3.28,<0.3.29.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 2934061
   timestamp: 1723931625423
 - kind: conda
@@ -7940,6 +8375,7 @@ packages:
   - openblas >=0.3.28,<0.3.29.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6052706
   timestamp: 1723932292682
 - kind: conda
@@ -7959,6 +8395,7 @@ packages:
   - openblas >=0.3.28,<0.3.29.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 5572213
   timestamp: 1723932528810
 - kind: conda
@@ -7973,6 +8410,7 @@ packages:
   - __osx >=10.13
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
+  purls: []
   size: 268073
   timestamp: 1726234803010
 - kind: conda
@@ -7988,6 +8426,7 @@ packages:
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
+  purls: []
   size: 290661
   timestamp: 1726234747153
 - kind: conda
@@ -8002,6 +8441,7 @@ packages:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
+  purls: []
   size: 263385
   timestamp: 1726234714421
 - kind: conda
@@ -8018,6 +8458,7 @@ packages:
   - libstdcxx >=12.4.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 3947704
   timestamp: 1724801833649
 - kind: conda
@@ -8031,6 +8472,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: ISC
+  purls: []
   size: 205978
   timestamp: 1716828628198
 - kind: conda
@@ -8044,6 +8486,7 @@ packages:
   depends:
   - __osx >=11.0
   license: ISC
+  purls: []
   size: 164972
   timestamp: 1716828607917
 - kind: conda
@@ -8057,6 +8500,7 @@ packages:
   depends:
   - __osx >=10.13
   license: ISC
+  purls: []
   size: 210249
   timestamp: 1716828641383
 - kind: conda
@@ -8072,6 +8516,7 @@ packages:
   - __osx >=10.13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
+  purls: []
   size: 915300
   timestamp: 1730208101739
 - kind: conda
@@ -8088,6 +8533,7 @@ packages:
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
+  purls: []
   size: 875349
   timestamp: 1730208050020
 - kind: conda
@@ -8103,6 +8549,7 @@ packages:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
+  purls: []
   size: 837683
   timestamp: 1730208293578
 - kind: conda
@@ -8117,6 +8564,7 @@ packages:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
+  purls: []
   size: 850553
   timestamp: 1733762057506
 - kind: conda
@@ -8131,6 +8579,7 @@ packages:
   - __osx >=10.13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
+  purls: []
   size: 923167
   timestamp: 1733761860127
 - kind: conda
@@ -8146,6 +8595,7 @@ packages:
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
+  purls: []
   size: 873551
   timestamp: 1733761824646
 - kind: conda
@@ -8162,6 +8612,7 @@ packages:
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 271133
   timestamp: 1685837707056
 - kind: conda
@@ -8177,6 +8628,7 @@ packages:
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 255610
   timestamp: 1685837894256
 - kind: conda
@@ -8192,6 +8644,7 @@ packages:
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 259556
   timestamp: 1685837820566
 - kind: conda
@@ -8207,6 +8660,7 @@ packages:
   - libgcc 14.2.0 h77fa898_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 3893695
   timestamp: 1729027746910
 - kind: conda
@@ -8223,6 +8677,7 @@ packages:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 11890684
   timestamp: 1724801712899
 - kind: conda
@@ -8238,6 +8693,7 @@ packages:
   - libstdcxx 14.2.0 hc0a3c3a_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 54105
   timestamp: 1729027780628
 - kind: conda
@@ -8259,6 +8715,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: HPND
+  purls: []
   size: 395973
   timestamp: 1726667328916
 - kind: conda
@@ -8280,6 +8737,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: HPND
+  purls: []
   size: 367224
   timestamp: 1726667500299
 - kind: conda
@@ -8303,6 +8761,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   license: HPND
+  purls: []
   size: 428156
   timestamp: 1728232228989
 - kind: conda
@@ -8317,6 +8776,7 @@ packages:
   - libgcc-ng >=12
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 33601
   timestamp: 1680112270483
 - kind: conda
@@ -8331,6 +8791,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 410500
   timestamp: 1729322654121
 - kind: conda
@@ -8346,6 +8807,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 884647
   timestamp: 1729322566955
 - kind: conda
@@ -8360,6 +8822,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 413607
   timestamp: 1729322686826
 - kind: conda
@@ -8374,6 +8837,7 @@ packages:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 355099
   timestamp: 1713200298965
 - kind: conda
@@ -8388,6 +8852,7 @@ packages:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 287750
   timestamp: 1713200194013
 - kind: conda
@@ -8404,6 +8869,7 @@ packages:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 438953
   timestamp: 1713199854503
 - kind: conda
@@ -8422,6 +8888,7 @@ packages:
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
+  purls: []
   size: 395888
   timestamp: 1727278577118
 - kind: conda
@@ -8436,6 +8903,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
+  purls: []
   size: 100393
   timestamp: 1702724383534
 - kind: conda
@@ -8455,6 +8923,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 588990
   timestamp: 1721031045514
 - kind: conda
@@ -8475,6 +8944,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 707169
   timestamp: 1721031016143
 - kind: conda
@@ -8494,6 +8964,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 619901
   timestamp: 1721031175411
 - kind: conda
@@ -8513,6 +8984,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 601997
   timestamp: 1730355958301
 - kind: conda
@@ -8532,6 +9004,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 572400
   timestamp: 1730356085177
 - kind: conda
@@ -8552,6 +9025,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 690019
   timestamp: 1730355770718
 - kind: conda
@@ -8573,6 +9047,7 @@ packages:
   - icu <0.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 689993
   timestamp: 1733443678322
 - kind: conda
@@ -8592,6 +9067,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 582898
   timestamp: 1733443841584
 - kind: conda
@@ -8612,6 +9088,7 @@ packages:
   - icu <0.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 609081
   timestamp: 1733443988169
 - kind: conda
@@ -8629,6 +9106,7 @@ packages:
   - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 46438
   timestamp: 1727963202283
 - kind: conda
@@ -8647,6 +9125,7 @@ packages:
   - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 60963
   timestamp: 1727963148474
 - kind: conda
@@ -8664,6 +9143,7 @@ packages:
   - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 57133
   timestamp: 1727963183990
 - kind: conda
@@ -8681,6 +9161,8 @@ packages:
   - uc-micro-py
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/linkify-it-py?source=hash-mapping
   size: 24154
   timestamp: 1733781296133
 - kind: conda
@@ -8697,6 +9179,7 @@ packages:
   - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 280737
   timestamp: 1729145191646
 - kind: conda
@@ -8713,6 +9196,7 @@ packages:
   - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 305589
   timestamp: 1729145249496
 - kind: conda
@@ -8728,6 +9212,7 @@ packages:
   constrains:
   - openmp 19.1.3|19.1.3.*
   license: Apache-2.0 WITH LLVM-exception
+  purls: []
   size: 280488
   timestamp: 1730364082380
 - kind: conda
@@ -8743,6 +9228,7 @@ packages:
   constrains:
   - openmp 19.1.3|19.1.3.*
   license: Apache-2.0 WITH LLVM-exception
+  purls: []
   size: 305524
   timestamp: 1730364180247
 - kind: conda
@@ -8759,6 +9245,7 @@ packages:
   - openmp 19.1.6|19.1.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 305048
   timestamp: 1734520356844
 - kind: conda
@@ -8775,6 +9262,7 @@ packages:
   - openmp 19.1.6|19.1.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
+  purls: []
   size: 281251
   timestamp: 1734520462311
 - kind: conda
@@ -8798,6 +9286,7 @@ packages:
   - llvm 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 20685770
   timestamp: 1701375136405
 - kind: conda
@@ -8821,6 +9310,7 @@ packages:
   - llvm 16.0.6.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 22221159
   timestamp: 1701379965425
 - kind: conda
@@ -8836,6 +9326,7 @@ packages:
   - __osx >=10.13
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 278910
   timestamp: 1727801765025
 - kind: conda
@@ -8852,6 +9343,7 @@ packages:
   - libgcc >=13
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 513088
   timestamp: 1727801714848
 - kind: conda
@@ -8867,6 +9359,7 @@ packages:
   - __osx >=11.0
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 274048
   timestamp: 1727801725384
 - kind: conda
@@ -8884,6 +9377,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/markdown-it-py?source=hash-mapping
   size: 64430
   timestamp: 1733250550053
 - kind: conda
@@ -8903,6 +9398,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
   size: 22752
   timestamp: 1729351484481
 - kind: conda
@@ -8921,6 +9418,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
   size: 21976
   timestamp: 1729351462576
 - kind: conda
@@ -8940,6 +9439,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
   size: 22993
   timestamp: 1729351433689
 - kind: conda
@@ -8956,6 +9457,8 @@ packages:
   - traitlets
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/matplotlib-inline?source=hash-mapping
   size: 14599
   timestamp: 1713250613726
 - kind: conda
@@ -8975,6 +9478,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 4823976
   timestamp: 1727350625865
 - kind: conda
@@ -8994,6 +9499,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 6258004
   timestamp: 1727350288645
 - kind: conda
@@ -9012,6 +9519,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 4992900
   timestamp: 1727350926555
 - kind: conda
@@ -9030,6 +9539,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 4990870
   timestamp: 1727350675611
 - kind: conda
@@ -9049,6 +9560,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 4824310
   timestamp: 1727350717009
 - kind: conda
@@ -9068,6 +9581,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 6259823
   timestamp: 1727350293668
 - kind: conda
@@ -9086,6 +9601,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 4994299
   timestamp: 1727350842651
 - kind: conda
@@ -9105,6 +9622,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 6259502
   timestamp: 1727350499582
 - kind: conda
@@ -9124,6 +9643,8 @@ packages:
   - tomli >=1.1.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
   size: 4826424
   timestamp: 1727350741008
 - kind: conda
@@ -9141,6 +9662,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mdit-py-plugins?source=hash-mapping
   size: 42180
   timestamp: 1733854816517
 - kind: conda
@@ -9157,6 +9680,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
 - kind: conda
@@ -9172,6 +9697,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/mistune?source=hash-mapping
   size: 66022
   timestamp: 1698947249750
 - kind: conda
@@ -9189,6 +9716,7 @@ packages:
   - mpfr >=4.2.1,<5.0a0
   license: LGPL-3.0-or-later
   license_family: LGPL
+  purls: []
   size: 104766
   timestamp: 1725629165420
 - kind: conda
@@ -9206,6 +9734,7 @@ packages:
   - mpfr >=4.2.1,<5.0a0
   license: LGPL-3.0-or-later
   license_family: LGPL
+  purls: []
   size: 107774
   timestamp: 1725629348601
 - kind: conda
@@ -9222,6 +9751,7 @@ packages:
   - gmp >=6.3.0,<7.0a0
   license: LGPL-3.0-only
   license_family: LGPL
+  purls: []
   size: 373396
   timestamp: 1725746891597
 - kind: conda
@@ -9238,6 +9768,7 @@ packages:
   - gmp >=6.3.0,<7.0a0
   license: LGPL-3.0-only
   license_family: LGPL
+  purls: []
   size: 345517
   timestamp: 1725746730583
 - kind: conda
@@ -9254,6 +9785,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/msgspec?source=hash-mapping
   size: 203048
   timestamp: 1705901843751
 - kind: conda
@@ -9269,6 +9802,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/msgspec?source=hash-mapping
   size: 187255
   timestamp: 1705901984422
 - kind: conda
@@ -9285,6 +9820,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/msgspec?source=hash-mapping
   size: 179690
   timestamp: 1705902055572
 - kind: conda
@@ -9310,6 +9847,8 @@ packages:
   - sphinx >=5
   - typing_extensions
   license: BSD-3-Clause
+  purls:
+  - pkg:pypi/myst-nb?source=hash-mapping
   size: 63037
   timestamp: 1734615289752
 - kind: conda
@@ -9331,6 +9870,8 @@ packages:
   - sphinx >=6,<8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/myst-parser?source=hash-mapping
   size: 67063
   timestamp: 1686686421092
 - kind: conda
@@ -9350,6 +9891,8 @@ packages:
   - traitlets >=5.4
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/nbclient?source=hash-mapping
   size: 27851
   timestamp: 1710317767117
 - kind: conda
@@ -9385,6 +9928,8 @@ packages:
   - pandoc >=2.9.2,<4.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/nbconvert?source=hash-mapping
   size: 189599
   timestamp: 1718135529468
 - kind: conda
@@ -9404,6 +9949,8 @@ packages:
   - traitlets >=5.1
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/nbformat?source=hash-mapping
   size: 101232
   timestamp: 1712239122969
 - kind: conda
@@ -9418,6 +9965,7 @@ packages:
   depends:
   - __osx >=11.0
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 802321
   timestamp: 1724658775723
 - kind: conda
@@ -9433,6 +9981,7 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 889086
   timestamp: 1724658547447
 - kind: conda
@@ -9447,6 +9996,7 @@ packages:
   depends:
   - __osx >=10.13
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 822066
   timestamp: 1724658603042
 - kind: conda
@@ -9462,6 +10012,8 @@ packages:
   - python >=3.5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/nest-asyncio?source=hash-mapping
   size: 11638
   timestamp: 1705850780510
 - kind: conda
@@ -9478,6 +10030,8 @@ packages:
   - setuptools
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/nodeenv?source=hash-mapping
   size: 34489
   timestamp: 1717585382642
 - kind: conda
@@ -9495,6 +10049,8 @@ packages:
   - setuptools
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/nodeenv?source=hash-mapping
   size: 34574
   timestamp: 1734112236147
 - kind: conda
@@ -9511,6 +10067,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/notebook-shim?source=hash-mapping
   size: 16880
   timestamp: 1707957948029
 - kind: conda
@@ -9526,6 +10084,7 @@ packages:
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 2882450
   timestamp: 1725410638874
 - kind: conda
@@ -9542,6 +10101,7 @@ packages:
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 2891789
   timestamp: 1725410790053
 - kind: conda
@@ -9557,6 +10117,7 @@ packages:
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 2544654
   timestamp: 1725410973572
 - kind: conda
@@ -9573,6 +10134,8 @@ packages:
   - typing_utils
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/overrides?source=hash-mapping
   size: 30232
   timestamp: 1706394723472
 - kind: conda
@@ -9588,6 +10151,8 @@ packages:
   - python >=3.8
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/packaging?source=hash-mapping
   size: 50290
   timestamp: 1718189540074
 - kind: conda
@@ -9604,6 +10169,8 @@ packages:
   - python >=3.8
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/packaging?source=hash-mapping
   size: 60164
   timestamp: 1733203368787
 - kind: conda
@@ -9616,6 +10183,7 @@ packages:
   md5: 4c2700fd13f9dbd7929d20eedde984ee
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 14073476
   timestamp: 1728196394225
 - kind: conda
@@ -9628,6 +10196,7 @@ packages:
   md5: 2889e6b9c666c3a564ab90cedc5832fd
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 21003150
   timestamp: 1728196276862
 - kind: conda
@@ -9640,6 +10209,7 @@ packages:
   md5: 5c56b7bfbdad3334a09230d405b63564
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 22892672
   timestamp: 1728196385862
 - kind: conda
@@ -9655,6 +10225,8 @@ packages:
   - python !=3.0,!=3.1,!=3.2,!=3.3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pandocfilters?source=hash-mapping
   size: 11627
   timestamp: 1631603397334
 - kind: conda
@@ -9677,6 +10249,7 @@ packages:
   - libglib >=2.80.3,<3.0a0
   - libpng >=1.6.43,<1.7.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 423324
   timestamp: 1723832327771
 - kind: conda
@@ -9699,6 +10272,7 @@ packages:
   - libglib >=2.80.2,<3.0a0
   - libpng >=1.6.43,<1.7.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 447117
   timestamp: 1719839527713
 - kind: conda
@@ -9721,6 +10295,7 @@ packages:
   - libglib >=2.80.3,<3.0a0
   - libpng >=1.6.43,<1.7.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 417224
   timestamp: 1723832458095
 - kind: conda
@@ -9736,6 +10311,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/parso?source=hash-mapping
   size: 75191
   timestamp: 1712320447201
 - kind: conda
@@ -9753,6 +10330,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 618973
   timestamp: 1723488853807
 - kind: conda
@@ -9770,6 +10348,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 854306
   timestamp: 1723488807216
 - kind: conda
@@ -9788,6 +10367,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 952308
   timestamp: 1723488734144
 - kind: conda
@@ -9803,6 +10383,8 @@ packages:
   - ptyprocess >=0.5
   - python >=3.7
   license: ISC
+  purls:
+  - pkg:pypi/pexpect?source=hash-mapping
   size: 53600
   timestamp: 1706113273252
 - kind: conda
@@ -9819,6 +10401,8 @@ packages:
   - python >=3
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pickleshare?source=hash-mapping
   size: 9332
   timestamp: 1602536313357
 - kind: conda
@@ -9836,6 +10420,8 @@ packages:
   - wheel
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pip?source=hash-mapping
   size: 1243168
   timestamp: 1730203795600
 - kind: conda
@@ -9854,6 +10440,8 @@ packages:
   - wheel
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pip?source=hash-mapping
   size: 1245116
   timestamp: 1734466348103
 - kind: conda
@@ -9872,6 +10460,8 @@ packages:
   - python >=3.8,<4.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pixi-kernel?source=hash-mapping
   size: 638493
   timestamp: 1721937102812
 - kind: conda
@@ -9887,6 +10477,7 @@ packages:
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 386826
   timestamp: 1706549500138
 - kind: conda
@@ -9901,6 +10492,7 @@ packages:
   - libcxx >=16
   license: MIT
   license_family: MIT
+  purls: []
   size: 323904
   timestamp: 1709239931160
 - kind: conda
@@ -9915,6 +10507,7 @@ packages:
   - libcxx >=16
   license: MIT
   license_family: MIT
+  purls: []
   size: 198755
   timestamp: 1709239846651
 - kind: conda
@@ -9931,6 +10524,7 @@ packages:
   - libgcc-ng >=12
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 115175
   timestamp: 1720805894943
 - kind: conda
@@ -9948,6 +10542,7 @@ packages:
   - libiconv >=1.17,<2.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 49724
   timestamp: 1720806128118
 - kind: conda
@@ -9964,6 +10559,7 @@ packages:
   - libiconv >=1.17,<2.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 239818
   timestamp: 1720806136579
 - kind: conda
@@ -9979,6 +10575,8 @@ packages:
   depends:
   - python >=3.6
   license: MIT AND PSF-2.0
+  purls:
+  - pkg:pypi/pkgutil-resolve-name?source=hash-mapping
   size: 10778
   timestamp: 1694617398467
 - kind: conda
@@ -9994,6 +10592,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/platformdirs?source=hash-mapping
   size: 20625
   timestamp: 1726613611845
 - kind: conda
@@ -10010,6 +10610,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/platformdirs?source=hash-mapping
   size: 20448
   timestamp: 1733232756001
 - kind: conda
@@ -10026,6 +10628,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=hash-mapping
   size: 23595
   timestamp: 1733222855563
 - kind: conda
@@ -10046,6 +10650,8 @@ packages:
   - virtualenv >=20.10.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pre-commit?source=hash-mapping
   size: 194633
   timestamp: 1728420305558
 - kind: conda
@@ -10067,6 +10673,8 @@ packages:
   - virtualenv >=20.10.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pre-commit?source=hash-mapping
   size: 193591
   timestamp: 1734267205422
 - kind: conda
@@ -10082,6 +10690,8 @@ packages:
   - python >=3.8
   license: Apache-2.0
   license_family: Apache
+  purls:
+  - pkg:pypi/prometheus-client?source=hash-mapping
   size: 49024
   timestamp: 1726902073034
 - kind: conda
@@ -10100,6 +10710,8 @@ packages:
   - prompt_toolkit 3.0.48
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/prompt-toolkit?source=hash-mapping
   size: 270271
   timestamp: 1727341744544
 - kind: conda
@@ -10117,6 +10729,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
   size: 368823
   timestamp: 1729847140562
 - kind: conda
@@ -10133,6 +10747,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
   size: 376905
   timestamp: 1729847426479
 - kind: conda
@@ -10150,6 +10766,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
   size: 376431
   timestamp: 1729847288915
 - kind: conda
@@ -10166,6 +10784,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 8252
   timestamp: 1726802366959
 - kind: conda
@@ -10180,6 +10799,8 @@ packages:
   depends:
   - python
   license: ISC
+  purls:
+  - pkg:pypi/ptyprocess?source=hash-mapping
   size: 16546
   timestamp: 1609419417991
 - kind: conda
@@ -10195,8 +10816,28 @@ packages:
   - python >=3.5
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pure-eval?source=hash-mapping
   size: 16551
   timestamp: 1721585805256
+- kind: conda
+  name: py-cpuinfo
+  version: 9.0.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
+  sha256: 6d8f03c13d085a569fde931892cded813474acbef2e03381a1a87f420c7da035
+  md5: 46830ee16925d5ed250850503b5dc3a8
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/py-cpuinfo?source=hash-mapping
+  size: 25766
+  timestamp: 1733236452235
 - kind: conda
   name: pybtex
   version: 0.24.0
@@ -10215,6 +10856,8 @@ packages:
   - six
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pybtex?source=hash-mapping
   size: 73221
   timestamp: 1733928237757
 - kind: conda
@@ -10234,6 +10877,8 @@ packages:
   - setuptools
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pybtex-docutils?source=hash-mapping
   size: 15184
   timestamp: 1725691836718
 - kind: conda
@@ -10254,6 +10899,8 @@ packages:
   - setuptools
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pybtex-docutils?source=hash-mapping
   size: 15616
   timestamp: 1725691889557
 - kind: conda
@@ -10273,6 +10920,8 @@ packages:
   - setuptools
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pybtex-docutils?source=hash-mapping
   size: 15051
   timestamp: 1725691800447
 - kind: conda
@@ -10290,6 +10939,7 @@ packages:
   - python
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 110100
   timestamp: 1733195786147
 - kind: conda
@@ -10305,6 +10955,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pycparser?source=hash-mapping
   size: 105098
   timestamp: 1711811634025
 - kind: conda
@@ -10327,6 +10979,8 @@ packages:
   - typing_extensions
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pydata-sphinx-theme?source=hash-mapping
   size: 1547597
   timestamp: 1734446468767
 - kind: conda
@@ -10342,6 +10996,8 @@ packages:
   - python >=3.8
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=hash-mapping
   size: 879295
   timestamp: 1714846885370
 - kind: conda
@@ -10361,6 +11017,8 @@ packages:
   - setuptools
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
   size: 439688
   timestamp: 1725739930202
 - kind: conda
@@ -10381,6 +11039,8 @@ packages:
   - setuptools
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-core?source=hash-mapping
   size: 431134
   timestamp: 1725739637287
 - kind: conda
@@ -10400,6 +11060,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
   size: 335363
   timestamp: 1725875364870
 - kind: conda
@@ -10420,6 +11082,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
   size: 337442
   timestamp: 1725875206912
 - kind: conda
@@ -10437,6 +11101,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pysocks?source=hash-mapping
   size: 18981
   timestamp: 1661604969727
 - kind: conda
@@ -10461,8 +11127,28 @@ packages:
   - pytest-faulthandler >=2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pytest?source=hash-mapping
   size: 259195
   timestamp: 1733217599806
+- kind: conda
+  name: pytest-benchmark
+  version: 5.1.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
+  sha256: 6f3208ee181d2437aaa7e4ad64dacb149a0cb52d1975c86e520b371050b9c6ad
+  md5: e082fea65ca7bbde086013c8bf967df0
+  depends:
+  - py-cpuinfo
+  - pytest >=3.8
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 42736
+  timestamp: 1733277213500
 - kind: conda
   name: python
   version: 3.10.0
@@ -10486,6 +11172,7 @@ packages:
   constrains:
   - python_abi 3.10.* *_cp310
   license: Python-2.0
+  purls: []
   size: 13518160
   timestamp: 1637377444619
 - kind: conda
@@ -10511,6 +11198,7 @@ packages:
   constrains:
   - python_abi 3.10.* *_cp310
   license: Python-2.0
+  purls: []
   size: 12899235
   timestamp: 1637375579641
 - kind: conda
@@ -10540,6 +11228,7 @@ packages:
   constrains:
   - python_abi 3.10.* *_cp310
   license: Python-2.0
+  purls: []
   size: 31281695
   timestamp: 1637376125446
 - kind: conda
@@ -10571,6 +11260,7 @@ packages:
   constrains:
   - python_abi 3.10.* *_cp310
   license: Python-2.0
+  purls: []
   size: 25321141
   timestamp: 1729042931665
 - kind: conda
@@ -10597,6 +11287,7 @@ packages:
   constrains:
   - python_abi 3.10.* *_cp310
   license: Python-2.0
+  purls: []
   size: 12924349
   timestamp: 1729042113444
 - kind: conda
@@ -10623,6 +11314,7 @@ packages:
   constrains:
   - python_abi 3.10.* *_cp310
   license: Python-2.0
+  purls: []
   size: 12411616
   timestamp: 1729042103758
 - kind: conda
@@ -10650,6 +11342,7 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
+  purls: []
   size: 15442415
   timestamp: 1729043110107
 - kind: conda
@@ -10677,6 +11370,7 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
+  purls: []
   size: 14598065
   timestamp: 1729042279642
 - kind: conda
@@ -10709,6 +11403,7 @@ packages:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
+  purls: []
   size: 30543977
   timestamp: 1729043512711
 - kind: conda
@@ -10735,6 +11430,7 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
+  purls: []
   size: 12975439
   timestamp: 1728057819519
 - kind: conda
@@ -10761,6 +11457,7 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
+  purls: []
   size: 13761315
   timestamp: 1728058247482
 - kind: conda
@@ -10792,6 +11489,7 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
+  purls: []
   size: 31574780
   timestamp: 1728059777603
 - kind: conda
@@ -10819,6 +11517,7 @@ packages:
   - tzdata
   - xz >=5.2.6,<6.0a0
   license: Python-2.0
+  purls: []
   size: 13933848
   timestamp: 1729169951268
 - kind: conda
@@ -10846,6 +11545,7 @@ packages:
   - tzdata
   - xz >=5.2.6,<6.0a0
   license: Python-2.0
+  purls: []
   size: 12804842
   timestamp: 1729168680448
 - kind: conda
@@ -10876,6 +11576,7 @@ packages:
   - tzdata
   - xz >=5.2.6,<6.0a0
   license: Python-2.0
+  purls: []
   size: 33112481
   timestamp: 1728419573472
 - kind: conda
@@ -10892,6 +11593,8 @@ packages:
   - six >=1.5
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/python-dateutil?source=hash-mapping
   size: 222742
   timestamp: 1709299922152
 - kind: conda
@@ -10907,6 +11610,8 @@ packages:
   - python >=3.3
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/fastjsonschema?source=hash-mapping
   size: 226165
   timestamp: 1718477110630
 - kind: conda
@@ -10922,6 +11627,8 @@ packages:
   - python >=3.6
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/python-json-logger?source=hash-mapping
   size: 13383
   timestamp: 1677079727691
 - kind: conda
@@ -10937,6 +11644,7 @@ packages:
   - python 3.10.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6227
   timestamp: 1723823165457
 - kind: conda
@@ -10952,6 +11660,7 @@ packages:
   - python 3.10.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6319
   timestamp: 1723823093772
 - kind: conda
@@ -10967,6 +11676,7 @@ packages:
   - python 3.10.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6324
   timestamp: 1723823147856
 - kind: conda
@@ -10982,6 +11692,7 @@ packages:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6211
   timestamp: 1723823324668
 - kind: conda
@@ -10997,6 +11708,7 @@ packages:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6303
   timestamp: 1723823062672
 - kind: conda
@@ -11012,6 +11724,7 @@ packages:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6308
   timestamp: 1723823096865
 - kind: conda
@@ -11027,6 +11740,7 @@ packages:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6238
   timestamp: 1723823388266
 - kind: conda
@@ -11042,6 +11756,7 @@ packages:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6312
   timestamp: 1723823137004
 - kind: conda
@@ -11057,6 +11772,7 @@ packages:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6278
   timestamp: 1723823099686
 - kind: conda
@@ -11072,6 +11788,7 @@ packages:
   - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6217
   timestamp: 1723823393322
 - kind: conda
@@ -11087,6 +11804,7 @@ packages:
   - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6291
   timestamp: 1723823083064
 - kind: conda
@@ -11102,6 +11820,7 @@ packages:
   - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6322
   timestamp: 1723823058879
 - kind: conda
@@ -11117,6 +11836,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pytz?source=hash-mapping
   size: 188538
   timestamp: 1706886944988
 - kind: conda
@@ -11136,6 +11857,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 162312
   timestamp: 1725456439220
 - kind: conda
@@ -11154,6 +11877,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 164184
   timestamp: 1725456348769
 - kind: conda
@@ -11173,6 +11898,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 182609
   timestamp: 1725456280173
 - kind: conda
@@ -11191,6 +11918,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 193941
   timestamp: 1725456465818
 - kind: conda
@@ -11210,6 +11939,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 192321
   timestamp: 1725456528007
 - kind: conda
@@ -11229,6 +11960,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 212644
   timestamp: 1725456264282
 - kind: conda
@@ -11248,6 +11981,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 187143
   timestamp: 1725456547263
 - kind: conda
@@ -11267,6 +12002,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 206553
   timestamp: 1725456256213
 - kind: conda
@@ -11285,6 +12022,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 189347
   timestamp: 1725456465705
 - kind: conda
@@ -11304,6 +12043,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 187550
   timestamp: 1725456463634
 - kind: conda
@@ -11323,6 +12064,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 205855
   timestamp: 1725456273924
 - kind: conda
@@ -11341,6 +12084,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 190014
   timestamp: 1725456352876
 - kind: conda
@@ -11361,6 +12106,8 @@ packages:
   - zeromq >=4.3.5,<4.4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pyzmq?source=hash-mapping
   size: 315105
   timestamp: 1728642507585
 - kind: conda
@@ -11382,6 +12129,8 @@ packages:
   - zeromq >=4.3.5,<4.4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pyzmq?source=hash-mapping
   size: 338103
   timestamp: 1728642374037
 - kind: conda
@@ -11403,6 +12152,8 @@ packages:
   - zeromq >=4.3.5,<4.4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pyzmq?source=hash-mapping
   size: 314132
   timestamp: 1728642745677
 - kind: conda
@@ -11420,6 +12171,7 @@ packages:
   - r-recommended
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 17992
   timestamp: 1722424567478
 - kind: conda
@@ -11436,6 +12188,7 @@ packages:
   - r-sys >=2.1
   license: MIT
   license_family: MIT
+  purls: []
   size: 31804
   timestamp: 1728039803908
 - kind: conda
@@ -11452,6 +12205,7 @@ packages:
   - r-sys >=2.1
   license: MIT
   license_family: MIT
+  purls: []
   size: 30782
   timestamp: 1728039729274
 - kind: conda
@@ -11469,6 +12223,7 @@ packages:
   - r-sys >=2.1
   license: MIT
   license_family: MIT
+  purls: []
   size: 31675
   timestamp: 1728039758510
 - kind: conda
@@ -11485,6 +12240,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 72188
   timestamp: 1719739348759
 - kind: conda
@@ -11538,6 +12294,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 27645849
   timestamp: 1723489876581
 - kind: conda
@@ -11591,6 +12348,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 26751606
   timestamp: 1723489498922
 - kind: conda
@@ -11645,6 +12403,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 27136871
   timestamp: 1728291957055
 - kind: conda
@@ -11661,6 +12420,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 45877
   timestamp: 1719739050604
 - kind: conda
@@ -11677,6 +12437,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 44990
   timestamp: 1719738970351
 - kind: conda
@@ -11693,6 +12454,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 45961
   timestamp: 1719738917121
 - kind: conda
@@ -11708,6 +12470,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: Unlimited
   license_family: Other
+  purls: []
   size: 644949
   timestamp: 1724870880174
 - kind: conda
@@ -11724,6 +12487,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-only
   license_family: GPL2
+  purls: []
   size: 68014
   timestamp: 1719737673264
 - kind: conda
@@ -11740,6 +12504,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 43757
   timestamp: 1719738313508
 - kind: conda
@@ -11756,6 +12521,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 42722
   timestamp: 1719738204337
 - kind: conda
@@ -11772,6 +12538,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 43888
   timestamp: 1719738120143
 - kind: conda
@@ -11797,6 +12564,7 @@ packages:
   - r-sass >=0.4.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 4728897
   timestamp: 1722295003601
 - kind: conda
@@ -11815,6 +12583,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 76154
   timestamp: 1719745787978
 - kind: conda
@@ -11833,6 +12602,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 75430
   timestamp: 1719745771726
 - kind: conda
@@ -11851,6 +12621,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 76353
   timestamp: 1719745589253
 - kind: conda
@@ -11869,6 +12640,7 @@ packages:
   - r-r6
   license: MIT
   license_family: MIT
+  purls: []
   size: 451360
   timestamp: 1719744575007
 - kind: conda
@@ -11886,6 +12658,7 @@ packages:
   - r-mass
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 107676
   timestamp: 1719753117694
 - kind: conda
@@ -11903,6 +12676,7 @@ packages:
   - r-mass
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 110022
   timestamp: 1719793999921
 - kind: conda
@@ -11920,6 +12694,7 @@ packages:
   - r-mass
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 109070
   timestamp: 1719752943344
 - kind: conda
@@ -11938,6 +12713,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1282188
   timestamp: 1721158789415
 - kind: conda
@@ -11955,6 +12731,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1281071
   timestamp: 1721158801769
 - kind: conda
@@ -11972,6 +12749,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1279765
   timestamp: 1721158896603
 - kind: conda
@@ -11988,6 +12766,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 70318
   timestamp: 1719752300954
 - kind: conda
@@ -12007,6 +12786,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 584542
   timestamp: 1719760359909
 - kind: conda
@@ -12026,6 +12806,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 590681
   timestamp: 1719760219453
 - kind: conda
@@ -12044,6 +12825,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 589715
   timestamp: 1719760163226
 - kind: conda
@@ -12060,6 +12842,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 108972
   timestamp: 1719730929593
 - kind: conda
@@ -12075,6 +12858,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 118514
   timestamp: 1728060040288
 - kind: conda
@@ -12090,6 +12874,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 121330
   timestamp: 1728059955247
 - kind: conda
@@ -12106,6 +12891,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 136956
   timestamp: 1728059960376
 - kind: conda
@@ -12121,6 +12907,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 223483
   timestamp: 1724750579080
 - kind: conda
@@ -12137,6 +12924,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 167792
   timestamp: 1719730626265
 - kind: conda
@@ -12157,6 +12945,7 @@ packages:
   - r-sys >=2.1
   license: MIT
   license_family: MIT
+  purls: []
   size: 226228
   timestamp: 1728058026467
 - kind: conda
@@ -12174,6 +12963,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 455953
   timestamp: 1721289671301
 - kind: conda
@@ -12192,6 +12982,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 456810
   timestamp: 1721289177543
 - kind: conda
@@ -12209,6 +13000,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 454581
   timestamp: 1721289328943
 - kind: conda
@@ -12228,6 +13020,7 @@ packages:
   - r-rprojroot
   license: MIT
   license_family: MIT
+  purls: []
   size: 339794
   timestamp: 1721176801811
 - kind: conda
@@ -12265,6 +13058,7 @@ packages:
   - r-withr >=2.5.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 430919
   timestamp: 1722690902312
 - kind: conda
@@ -12282,6 +13076,7 @@ packages:
   - r-crayon >=1.3.2
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 980163
   timestamp: 1719745300443
 - kind: conda
@@ -12299,6 +13094,7 @@ packages:
   - r-crayon >=1.3.2
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 979262
   timestamp: 1719745184680
 - kind: conda
@@ -12316,6 +13112,7 @@ packages:
   - r-crayon >=1.3.2
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 990441
   timestamp: 1719745113060
 - kind: conda
@@ -12333,6 +13130,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 217476
   timestamp: 1724100133893
 - kind: conda
@@ -12349,6 +13147,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 210583
   timestamp: 1724100224102
 - kind: conda
@@ -12365,6 +13164,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 205807
   timestamp: 1724100284595
 - kind: conda
@@ -12391,6 +13191,7 @@ packages:
   - r-yaml
   license: MIT
   license_family: MIT
+  purls: []
   size: 121502
   timestamp: 1721258784434
 - kind: conda
@@ -12408,6 +13209,7 @@ packages:
   - r-rlang >=0.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 43408
   timestamp: 1719732048084
 - kind: conda
@@ -12425,6 +13227,7 @@ packages:
   - r-rlang >=0.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 42540
   timestamp: 1719731954588
 - kind: conda
@@ -12442,6 +13245,7 @@ packages:
   - r-rlang >=0.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 43503
   timestamp: 1719731852391
 - kind: conda
@@ -12457,6 +13261,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 110090
   timestamp: 1728587123208
 - kind: conda
@@ -12473,6 +13278,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 320637
   timestamp: 1719732043756
 - kind: conda
@@ -12489,6 +13295,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 320074
   timestamp: 1719731958370
 - kind: conda
@@ -12505,6 +13312,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 326083
   timestamp: 1719731943730
 - kind: conda
@@ -12522,6 +13330,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 73493
   timestamp: 1719731743295
 - kind: conda
@@ -12539,6 +13348,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 73299
   timestamp: 1719731695134
 - kind: conda
@@ -12556,6 +13366,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 72928
   timestamp: 1719731911805
 - kind: conda
@@ -12574,6 +13385,7 @@ packages:
   - r-rlang >=0.4.10
   license: MIT
   license_family: MIT
+  purls: []
   size: 1300902
   timestamp: 1719764803883
 - kind: conda
@@ -12590,6 +13402,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 263359
   timestamp: 1719767322059
 - kind: conda
@@ -12606,6 +13419,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 265519
   timestamp: 1719767242175
 - kind: conda
@@ -12622,6 +13436,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 269293
   timestamp: 1719767154457
 - kind: conda
@@ -12638,6 +13453,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 295513
   timestamp: 1730293261001
 - kind: conda
@@ -12655,6 +13471,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 510141
   timestamp: 1730293034927
 - kind: conda
@@ -12671,6 +13488,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 299093
   timestamp: 1730293260960
 - kind: conda
@@ -12693,6 +13511,7 @@ packages:
   - r-zip >=2.1.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 264437
   timestamp: 1728929974120
 - kind: conda
@@ -12714,6 +13533,7 @@ packages:
   - r-zip >=2.1.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 261725
   timestamp: 1728930055645
 - kind: conda
@@ -12735,6 +13555,7 @@ packages:
   - r-zip >=2.1.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 262662
   timestamp: 1728930096554
 - kind: conda
@@ -12757,6 +13578,7 @@ packages:
   - r-rlang >=1.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 125668
   timestamp: 1721489742001
 - kind: conda
@@ -12773,6 +13595,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 96167
   timestamp: 1719787015710
 - kind: conda
@@ -12788,6 +13611,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 165032
   timestamp: 1727754939858
 - kind: conda
@@ -12803,6 +13627,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 164253
   timestamp: 1727754921581
 - kind: conda
@@ -12819,6 +13644,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 165384
   timestamp: 1727754835654
 - kind: conda
@@ -12836,6 +13662,7 @@ packages:
   - r-xfun >=0.18
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 56480
   timestamp: 1719729969355
 - kind: conda
@@ -12858,6 +13685,7 @@ packages:
   - r-rlang >=0.4.10
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 364669
   timestamp: 1719753047623
 - kind: conda
@@ -12880,6 +13708,7 @@ packages:
   - r-rlang >=0.4.10
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 366312
   timestamp: 1719752984962
 - kind: conda
@@ -12902,6 +13731,7 @@ packages:
   - r-rlang >=0.4.10
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 365871
   timestamp: 1719753241047
 - kind: conda
@@ -12923,6 +13753,7 @@ packages:
   - r-yaml
   license: MIT
   license_family: MIT
+  purls: []
   size: 425062
   timestamp: 1722673532598
 - kind: conda
@@ -12945,6 +13776,7 @@ packages:
   - r-rcpp >=1.0.7
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 540651
   timestamp: 1721155495296
 - kind: conda
@@ -12967,6 +13799,7 @@ packages:
   - r-rcpp >=1.0.7
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 519793
   timestamp: 1721155389605
 - kind: conda
@@ -12989,6 +13822,7 @@ packages:
   - r-rcpp >=1.0.7
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 530187
   timestamp: 1721155755807
 - kind: conda
@@ -13015,6 +13849,7 @@ packages:
   - r-withr
   license: MIT
   license_family: MIT
+  purls: []
   size: 618491
   timestamp: 1727367613095
 - kind: conda
@@ -13031,6 +13866,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 32808
   timestamp: 1719786988916
 - kind: conda
@@ -13048,6 +13884,7 @@ packages:
   - r-htmltools
   license: MIT
   license_family: MIT
+  purls: []
   size: 306993
   timestamp: 1719764696283
 - kind: conda
@@ -13063,6 +13900,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 632270
   timestamp: 1726834837939
 - kind: conda
@@ -13078,6 +13916,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 633505
   timestamp: 1726834884929
 - kind: conda
@@ -13094,6 +13933,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 636264
   timestamp: 1726834781082
 - kind: conda
@@ -13114,6 +13954,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: Unlimited
   license_family: MIT
+  purls: []
   size: 100291
   timestamp: 1719747451171
 - kind: conda
@@ -13134,6 +13975,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: Unlimited
   license_family: MIT
+  purls: []
   size: 99907
   timestamp: 1719747278377
 - kind: conda
@@ -13153,6 +13995,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: Unlimited
   license_family: MIT
+  purls: []
   size: 102019
   timestamp: 1719747300132
 - kind: conda
@@ -13172,6 +14015,7 @@ packages:
   - r-yaml >=2.1.19
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 1028708
   timestamp: 1720544781819
 - kind: conda
@@ -13191,6 +14035,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 118780
   timestamp: 1719752893208
 - kind: conda
@@ -13210,6 +14055,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 133818
   timestamp: 1719752818091
 - kind: conda
@@ -13229,6 +14075,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 117058
   timestamp: 1719753102435
 - kind: conda
@@ -13245,6 +14092,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 1379828
   timestamp: 1719739275977
 - kind: conda
@@ -13261,6 +14109,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 1380737
   timestamp: 1719739205175
 - kind: conda
@@ -13277,6 +14126,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 1381264
   timestamp: 1719739202151
 - kind: conda
@@ -13296,6 +14146,7 @@ packages:
   - r-rlang >=1.0.6
   license: MIT
   license_family: GPL3
+  purls: []
   size: 124017
   timestamp: 1721176825295
 - kind: conda
@@ -13312,6 +14163,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 211244
   timestamp: 1719726308275
 - kind: conda
@@ -13328,6 +14180,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 209361
   timestamp: 1719726131548
 - kind: conda
@@ -13344,6 +14197,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 211539
   timestamp: 1719726130671
 - kind: conda
@@ -13360,6 +14214,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 1167329
   timestamp: 1719739409540
 - kind: conda
@@ -13376,6 +14231,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 1170246
   timestamp: 1719739273843
 - kind: conda
@@ -13392,6 +14248,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 1164570
   timestamp: 1719739205132
 - kind: conda
@@ -13411,6 +14268,7 @@ packages:
   - r-lattice
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 4065856
   timestamp: 1720816676113
 - kind: conda
@@ -13430,6 +14288,7 @@ packages:
   - r-lattice
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 3874683
   timestamp: 1720816798384
 - kind: conda
@@ -13449,6 +14308,7 @@ packages:
   - r-lattice
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 4013115
   timestamp: 1720816583732
 - kind: conda
@@ -13467,6 +14327,7 @@ packages:
   - r-rlang >=0.4.10
   license: MIT
   license_family: MIT
+  purls: []
   size: 57252
   timestamp: 1719757958650
 - kind: conda
@@ -13489,6 +14350,7 @@ packages:
   - r-nlme >=3.1_64
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 3276683
   timestamp: 1720835988563
 - kind: conda
@@ -13510,6 +14372,7 @@ packages:
   - r-nlme >=3.1_64
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 3325003
   timestamp: 1720835983882
 - kind: conda
@@ -13531,6 +14394,7 @@ packages:
   - r-nlme >=3.1_64
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 3252087
   timestamp: 1720836022739
 - kind: conda
@@ -13547,6 +14411,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 53093
   timestamp: 1719740056525
 - kind: conda
@@ -13563,6 +14428,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 52262
   timestamp: 1719739972154
 - kind: conda
@@ -13579,6 +14445,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 53024
   timestamp: 1719739945905
 - kind: conda
@@ -13597,6 +14464,7 @@ packages:
   - r-shiny >=0.13
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 54628
   timestamp: 1721257974332
 - kind: conda
@@ -13617,6 +14485,7 @@ packages:
   - r-lattice
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 2347727
   timestamp: 1719753117576
 - kind: conda
@@ -13637,6 +14506,7 @@ packages:
   - r-lattice
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 2359006
   timestamp: 1719752901942
 - kind: conda
@@ -13656,6 +14526,7 @@ packages:
   - r-lattice
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 2352590
   timestamp: 1719752846579
 - kind: conda
@@ -13673,6 +14544,7 @@ packages:
   - r-mass
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 130532
   timestamp: 1719754031498
 - kind: conda
@@ -13690,6 +14562,7 @@ packages:
   - r-mass
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 132887
   timestamp: 1719754052413
 - kind: conda
@@ -13707,6 +14580,7 @@ packages:
   - r-mass
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 131129
   timestamp: 1719753865839
 - kind: conda
@@ -13724,6 +14598,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 687613
   timestamp: 1726842548203
 - kind: conda
@@ -13741,6 +14616,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 689012
   timestamp: 1726842813787
 - kind: conda
@@ -13759,6 +14635,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 691934
   timestamp: 1726842344871
 - kind: conda
@@ -13783,6 +14660,7 @@ packages:
   - r-vctrs >=0.2.0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 621357
   timestamp: 1721228705360
 - kind: conda
@@ -13806,6 +14684,7 @@ packages:
   - r-withr >=2.1.2
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 215922
   timestamp: 1730151267985
 - kind: conda
@@ -13822,6 +14701,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 26708
   timestamp: 1719725347921
 - kind: conda
@@ -13857,6 +14737,7 @@ packages:
   - r-yaml
   license: MIT
   license_family: MIT
+  purls: []
   size: 881981
   timestamp: 1726633804893
 - kind: conda
@@ -13882,6 +14763,7 @@ packages:
   - r-withr >=2.4.3
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 235154
   timestamp: 1723414049157
 - kind: conda
@@ -13898,6 +14780,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 25406
   timestamp: 1719719238806
 - kind: conda
@@ -13916,6 +14799,7 @@ packages:
   - r-magrittr
   license: MIT
   license_family: MIT
+  purls: []
   size: 160389
   timestamp: 1719751163364
 - kind: conda
@@ -13934,6 +14818,7 @@ packages:
   - r-r6
   license: MIT
   license_family: MIT
+  purls: []
   size: 319587
   timestamp: 1719731297459
 - kind: conda
@@ -13952,6 +14837,7 @@ packages:
   - r-r6
   license: MIT
   license_family: MIT
+  purls: []
   size: 318057
   timestamp: 1719731202323
 - kind: conda
@@ -13970,6 +14856,7 @@ packages:
   - r-r6
   license: MIT
   license_family: MIT
+  purls: []
   size: 329546
   timestamp: 1719731316185
 - kind: conda
@@ -13990,6 +14877,7 @@ packages:
   - r-vctrs
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 229971
   timestamp: 1726854522469
 - kind: conda
@@ -14010,6 +14898,7 @@ packages:
   - r-vctrs
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 228970
   timestamp: 1726854430994
 - kind: conda
@@ -14031,6 +14920,7 @@ packages:
   - r-vctrs
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 229503
   timestamp: 1726854347839
 - kind: conda
@@ -14054,6 +14944,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 1590833
   timestamp: 1719766441283
 - kind: conda
@@ -14077,6 +14968,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 1590326
   timestamp: 1719766456071
 - kind: conda
@@ -14100,6 +14992,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 1590509
   timestamp: 1719766603573
 - kind: conda
@@ -14116,6 +15009,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 395010
   timestamp: 1730165204087
 - kind: conda
@@ -14131,6 +15025,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 388983
   timestamp: 1730165260329
 - kind: conda
@@ -14146,6 +15041,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 389353
   timestamp: 1730165376967
 - kind: conda
@@ -14167,6 +15063,7 @@ packages:
   - r-vctrs >=0.5
   license: MIT
   license_family: MIT
+  purls: []
   size: 496034
   timestamp: 1721229618756
 - kind: conda
@@ -14188,6 +15085,7 @@ packages:
   - r-vctrs >=0.5
   license: MIT
   license_family: MIT
+  purls: []
   size: 496021
   timestamp: 1721229638323
 - kind: conda
@@ -14210,6 +15108,7 @@ packages:
   - r-vctrs >=0.5
   license: MIT
   license_family: MIT
+  purls: []
   size: 495661
   timestamp: 1721229481678
 - kind: conda
@@ -14226,6 +15125,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 91028
   timestamp: 1719719089864
 - kind: conda
@@ -14248,6 +15148,7 @@ packages:
   - r-textshaping >=0.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 490429
   timestamp: 1726089995516
 - kind: conda
@@ -14270,6 +15171,7 @@ packages:
   - r-textshaping >=0.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 467334
   timestamp: 1726090210056
 - kind: conda
@@ -14293,6 +15195,7 @@ packages:
   - r-textshaping >=0.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 529913
   timestamp: 1726089932872
 - kind: conda
@@ -14309,6 +15212,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 53426
   timestamp: 1719745878132
 - kind: conda
@@ -14325,6 +15229,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 52526
   timestamp: 1719745846595
 - kind: conda
@@ -14341,6 +15246,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 53317
   timestamp: 1719745775965
 - kind: conda
@@ -14369,6 +15275,7 @@ packages:
   - r-xopen
   license: MIT
   license_family: MIT
+  purls: []
   size: 178569
   timestamp: 1721305717010
 - kind: conda
@@ -14386,6 +15293,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 2038954
   timestamp: 1721255435507
 - kind: conda
@@ -14402,6 +15310,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 2060082
   timestamp: 1721255447704
 - kind: conda
@@ -14418,6 +15327,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 2065777
   timestamp: 1721255601461
 - kind: conda
@@ -14449,6 +15359,7 @@ packages:
   - r-survival
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 18013
   timestamp: 1722411986763
 - kind: conda
@@ -14466,6 +15377,7 @@ packages:
   - r-tibble
   license: MIT
   license_family: MIT
+  purls: []
   size: 55563
   timestamp: 1721286448106
 - kind: conda
@@ -14482,6 +15394,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 435966
   timestamp: 1719711393217
 - kind: conda
@@ -14499,6 +15412,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 1576353
   timestamp: 1719713232639
 - kind: conda
@@ -14516,6 +15430,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 1574404
   timestamp: 1719713191794
 - kind: conda
@@ -14533,6 +15448,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 1572086
   timestamp: 1719713363176
 - kind: conda
@@ -14559,6 +15475,7 @@ packages:
   - r-yaml >=2.1.19
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 2086503
   timestamp: 1723891202306
 - kind: conda
@@ -14590,6 +15507,7 @@ packages:
   - r-xml2
   license: MIT
   license_family: GPL3
+  purls: []
   size: 690848
   timestamp: 1722650454227
 - kind: conda
@@ -14620,6 +15538,7 @@ packages:
   - r-xml2
   license: MIT
   license_family: GPL3
+  purls: []
   size: 695428
   timestamp: 1722650492858
 - kind: conda
@@ -14650,6 +15569,7 @@ packages:
   - r-xml2
   license: MIT
   license_family: GPL3
+  purls: []
   size: 839139
   timestamp: 1722650593652
 - kind: conda
@@ -14666,6 +15586,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 699844
   timestamp: 1719753689028
 - kind: conda
@@ -14682,6 +15603,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 706373
   timestamp: 1719753700779
 - kind: conda
@@ -14698,6 +15620,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 704133
   timestamp: 1719753552655
 - kind: conda
@@ -14714,6 +15637,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 110788
   timestamp: 1719711197723
 - kind: conda
@@ -14729,6 +15653,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 317657
   timestamp: 1729642827981
 - kind: conda
@@ -14747,6 +15672,7 @@ packages:
   - r-xml2 >=1.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 73772
   timestamp: 1722648741165
 - kind: conda
@@ -14770,6 +15696,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 2133217
   timestamp: 1719765633743
 - kind: conda
@@ -14793,6 +15720,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 2284593
   timestamp: 1719765481487
 - kind: conda
@@ -14816,6 +15744,7 @@ packages:
   - r-rlang
   license: MIT
   license_family: MIT
+  purls: []
   size: 2092244
   timestamp: 1719766026628
 - kind: conda
@@ -14834,6 +15763,7 @@ packages:
   - r-withr
   license: GPL-2.0-only
   license_family: GPL2
+  purls: []
   size: 195057
   timestamp: 1721177296503
 - kind: conda
@@ -14868,6 +15798,7 @@ packages:
   - r-xtable
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 3862619
   timestamp: 1722527693062
 - kind: conda
@@ -14885,6 +15816,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 51766
   timestamp: 1719746470143
 - kind: conda
@@ -14902,6 +15834,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 55008
   timestamp: 1719746126850
 - kind: conda
@@ -14919,6 +15852,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 51904
   timestamp: 1719746278068
 - kind: conda
@@ -14935,6 +15869,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 154855
   timestamp: 1719817147590
 - kind: conda
@@ -14951,6 +15886,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 156703
   timestamp: 1719817078053
 - kind: conda
@@ -14967,6 +15903,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL3
+  purls: []
   size: 155943
   timestamp: 1719817065747
 - kind: conda
@@ -14986,6 +15923,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: FOSS
   license_family: OTHER
+  purls: []
   size: 926624
   timestamp: 1721373161463
 - kind: conda
@@ -15004,6 +15942,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: FOSS
   license_family: OTHER
+  purls: []
   size: 869892
   timestamp: 1721373438560
 - kind: conda
@@ -15022,6 +15961,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: FOSS
   license_family: OTHER
+  purls: []
   size: 885186
   timestamp: 1721373378094
 - kind: conda
@@ -15045,6 +15985,7 @@ packages:
   - r-vctrs
   license: MIT
   license_family: MIT
+  purls: []
   size: 299976
   timestamp: 1721222775462
 - kind: conda
@@ -15062,6 +16003,7 @@ packages:
   - r-matrix
   license: LGPL-2.0-or-later
   license_family: LGPL
+  purls: []
   size: 6309582
   timestamp: 1720834933087
 - kind: conda
@@ -15079,6 +16021,7 @@ packages:
   - r-matrix
   license: LGPL-2.0-or-later
   license_family: LGPL
+  purls: []
   size: 6347097
   timestamp: 1720835026249
 - kind: conda
@@ -15097,6 +16040,7 @@ packages:
   - r-matrix
   license: LGPL-2.0-or-later
   license_family: LGPL
+  purls: []
   size: 6327420
   timestamp: 1720834827361
 - kind: conda
@@ -15112,6 +16056,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 49081
   timestamp: 1728053512242
 - kind: conda
@@ -15127,6 +16072,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 48358
   timestamp: 1728053543166
 - kind: conda
@@ -15143,6 +16089,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 49700
   timestamp: 1728053370225
 - kind: conda
@@ -15163,6 +16110,7 @@ packages:
   - r-lifecycle
   license: MIT
   license_family: MIT
+  purls: []
   size: 232877
   timestamp: 1721192696176
 - kind: conda
@@ -15184,6 +16132,7 @@ packages:
   - r-lifecycle
   license: MIT
   license_family: MIT
+  purls: []
   size: 256936
   timestamp: 1721192561764
 - kind: conda
@@ -15204,6 +16153,7 @@ packages:
   - r-lifecycle
   license: MIT
   license_family: MIT
+  purls: []
   size: 227438
   timestamp: 1721192869799
 - kind: conda
@@ -15241,6 +16191,7 @@ packages:
   - r-withr >=2.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1624273
   timestamp: 1721417567721
 - kind: conda
@@ -15277,6 +16228,7 @@ packages:
   - r-withr >=2.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1601671
   timestamp: 1721417682193
 - kind: conda
@@ -15313,6 +16265,7 @@ packages:
   - r-withr >=2.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1592314
   timestamp: 1721417735333
 - kind: conda
@@ -15336,6 +16289,7 @@ packages:
   - r-systemfonts >=1.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 112504
   timestamp: 1721711601844
 - kind: conda
@@ -15359,6 +16313,7 @@ packages:
   - r-systemfonts >=1.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 123169
   timestamp: 1721711459599
 - kind: conda
@@ -15382,6 +16337,7 @@ packages:
   - r-systemfonts >=1.0.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 113742
   timestamp: 1721711531729
 - kind: conda
@@ -15405,6 +16361,7 @@ packages:
   - r-vctrs >=0.4.2
   license: MIT
   license_family: MIT
+  purls: []
   size: 617006
   timestamp: 1721259587475
 - kind: conda
@@ -15428,6 +16385,7 @@ packages:
   - r-vctrs >=0.4.2
   license: MIT
   license_family: MIT
+  purls: []
   size: 616583
   timestamp: 1721259256371
 - kind: conda
@@ -15452,6 +16410,7 @@ packages:
   - r-vctrs >=0.4.2
   license: MIT
   license_family: MIT
+  purls: []
   size: 617446
   timestamp: 1721259179235
 - kind: conda
@@ -15468,6 +16427,7 @@ packages:
   - r-xfun >=0.5
   license: MIT
   license_family: MIT
+  purls: []
   size: 152316
   timestamp: 1730487477873
 - kind: conda
@@ -15487,6 +16447,7 @@ packages:
   - r-xml2
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 51954
   timestamp: 1722648664580
 - kind: conda
@@ -15522,6 +16483,7 @@ packages:
   - r-yaml
   license: MIT
   license_family: MIT
+  purls: []
   size: 896146
   timestamp: 1722257206609
 - kind: conda
@@ -15538,6 +16500,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 140291
   timestamp: 1719712296474
 - kind: conda
@@ -15554,6 +16517,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 139083
   timestamp: 1719712222031
 - kind: conda
@@ -15570,6 +16534,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: Apache-2.0
   license_family: APACHE
+  purls: []
   size: 144010
   timestamp: 1719712202868
 - kind: conda
@@ -15592,6 +16557,7 @@ packages:
   - r-rlang >=1.0.6
   license: MIT
   license_family: MIT
+  purls: []
   size: 1263183
   timestamp: 1721192012589
 - kind: conda
@@ -15613,6 +16579,7 @@ packages:
   - r-rlang >=1.0.6
   license: MIT
   license_family: MIT
+  purls: []
   size: 1265699
   timestamp: 1721192131007
 - kind: conda
@@ -15634,6 +16601,7 @@ packages:
   - r-rlang >=1.0.6
   license: MIT
   license_family: MIT
+  purls: []
   size: 1244215
   timestamp: 1721192237548
 - kind: conda
@@ -15656,6 +16624,7 @@ packages:
   - r-tibble
   license: MIT
   license_family: MIT
+  purls: []
   size: 112506
   timestamp: 1724465463698
 - kind: conda
@@ -15672,6 +16641,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-3.0-only
   license_family: GPL3
+  purls: []
   size: 82304
   timestamp: 1719780355172
 - kind: conda
@@ -15687,6 +16657,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 234330
   timestamp: 1730138426588
 - kind: conda
@@ -15704,6 +16675,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 548153
   timestamp: 1728026305253
 - kind: conda
@@ -15720,6 +16692,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 548512
   timestamp: 1728026372293
 - kind: conda
@@ -15736,6 +16709,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 548440
   timestamp: 1728026532561
 - kind: conda
@@ -15756,6 +16730,7 @@ packages:
   - r-rlang >=1.1.0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 349399
   timestamp: 1722634361637
 - kind: conda
@@ -15777,6 +16752,7 @@ packages:
   - r-rlang >=1.1.0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 349528
   timestamp: 1722634249003
 - kind: conda
@@ -15797,6 +16773,7 @@ packages:
   - r-rlang >=1.1.0
   license: GPL-2.0-or-later
   license_family: GPL2
+  purls: []
   size: 200365
   timestamp: 1722634497899
 - kind: conda
@@ -15814,6 +16791,7 @@ packages:
   - r-processx
   license: MIT
   license_family: MIT
+  purls: []
   size: 32892
   timestamp: 1719858442899
 - kind: conda
@@ -15830,6 +16808,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: GPL (>= 2)
   license_family: GPL3
+  purls: []
   size: 703561
   timestamp: 1719744993639
 - kind: conda
@@ -15845,6 +16824,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 106489
   timestamp: 1722028043964
 - kind: conda
@@ -15860,6 +16840,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 109023
   timestamp: 1722027933107
 - kind: conda
@@ -15876,6 +16857,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 119482
   timestamp: 1722027917927
 - kind: conda
@@ -15892,6 +16874,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: CC
+  purls: []
   size: 123636
   timestamp: 1719782073527
 - kind: conda
@@ -15908,6 +16891,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: CC
+  purls: []
   size: 126010
   timestamp: 1719782038377
 - kind: conda
@@ -15924,6 +16908,7 @@ packages:
   - r-base >=4.4,<4.5.0a0
   license: MIT
   license_family: CC
+  purls: []
   size: 134862
   timestamp: 1719781880798
 - kind: conda
@@ -15940,6 +16925,7 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 281456
   timestamp: 1679532220005
 - kind: conda
@@ -15955,6 +16941,7 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 250351
   timestamp: 1679532511311
 - kind: conda
@@ -15970,6 +16957,7 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 255870
   timestamp: 1679532707590
 - kind: conda
@@ -15987,6 +16975,8 @@ packages:
   - rpds-py >=0.7.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/referencing?source=hash-mapping
   size: 42210
   timestamp: 1714619625532
 - kind: conda
@@ -16008,6 +16998,8 @@ packages:
   - chardet >=3.0.2,<6
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/requests?source=hash-mapping
   size: 58810
   timestamp: 1717057174842
 - kind: conda
@@ -16024,6 +17016,8 @@ packages:
   - six
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/rfc3339-validator?source=hash-mapping
   size: 8064
   timestamp: 1638811838081
 - kind: conda
@@ -16039,6 +17033,8 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/rfc3986-validator?source=hash-mapping
   size: 7818
   timestamp: 1598024297745
 - kind: conda
@@ -16058,6 +17054,8 @@ packages:
   - __glibc >=2.17
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/rpds-py?source=hash-mapping
   size: 334229
   timestamp: 1730922794405
 - kind: conda
@@ -16076,6 +17074,8 @@ packages:
   - __osx >=10.13
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/rpds-py?source=hash-mapping
   size: 301434
   timestamp: 1730923015524
 - kind: conda
@@ -16095,6 +17095,8 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/rpds-py?source=hash-mapping
   size: 293748
   timestamp: 1730923008139
 - kind: conda
@@ -16114,6 +17116,7 @@ packages:
   - sysroot_linux-64 >=2.17
   license: MIT
   license_family: MIT
+  purls: []
   size: 200303283
   timestamp: 1726504386467
 - kind: conda
@@ -16128,6 +17131,7 @@ packages:
   - rust-std-aarch64-apple-darwin 1.81.0 hf6ec828_0
   license: MIT
   license_family: MIT
+  purls: []
   size: 199771549
   timestamp: 1726506487060
 - kind: conda
@@ -16142,6 +17146,7 @@ packages:
   - rust-std-x86_64-apple-darwin 1.81.0 h38e4360_0
   license: MIT
   license_family: MIT
+  purls: []
   size: 205216960
   timestamp: 1726505981140
 - kind: conda
@@ -16161,6 +17166,7 @@ packages:
   - sysroot_linux-64 >=2.17
   license: MIT
   license_family: MIT
+  purls: []
   size: 207339733
   timestamp: 1732866100765
 - kind: conda
@@ -16175,6 +17181,7 @@ packages:
   - rust-std-x86_64-apple-darwin 1.83.0 h38e4360_0
   license: MIT
   license_family: MIT
+  purls: []
   size: 211385807
   timestamp: 1732868281397
 - kind: conda
@@ -16189,6 +17196,7 @@ packages:
   - rust-std-aarch64-apple-darwin 1.83.0 hf6ec828_0
   license: MIT
   license_family: MIT
+  purls: []
   size: 205660015
   timestamp: 1732868152162
 - kind: conda
@@ -16206,6 +17214,7 @@ packages:
   - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 3343744
   timestamp: 1726503702978
 - kind: conda
@@ -16223,6 +17232,7 @@ packages:
   - rust >=1.83.0,<1.83.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 3459432
   timestamp: 1732865409487
 - kind: conda
@@ -16240,6 +17250,7 @@ packages:
   - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 31264180
   timestamp: 1726503800830
 - kind: conda
@@ -16257,6 +17268,7 @@ packages:
   - rust >=1.83.0,<1.83.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 31871459
   timestamp: 1732865328438
 - kind: conda
@@ -16274,6 +17286,7 @@ packages:
   - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 32202262
   timestamp: 1726503655773
 - kind: conda
@@ -16291,6 +17304,7 @@ packages:
   - rust >=1.83.0,<1.83.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 33864493
   timestamp: 1732865308546
 - kind: conda
@@ -16308,6 +17322,7 @@ packages:
   - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 34828353
   timestamp: 1726504171219
 - kind: conda
@@ -16325,6 +17340,7 @@ packages:
   - rust >=1.83.0,<1.83.1.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 36157084
   timestamp: 1732865947563
 - kind: conda
@@ -16338,6 +17354,7 @@ packages:
   depends:
   - libgcc-ng >=7.5.0
   license: GPL-3
+  purls: []
   size: 270762
   timestamp: 1605307395873
 - kind: conda
@@ -16354,6 +17371,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/send2trash?source=hash-mapping
   size: 22868
   timestamp: 1712585140895
 - kind: conda
@@ -16371,6 +17390,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/send2trash?source=hash-mapping
   size: 23165
   timestamp: 1712585504123
 - kind: conda
@@ -16386,6 +17407,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=hash-mapping
   size: 779561
   timestamp: 1730382173961
 - kind: conda
@@ -16402,6 +17425,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=hash-mapping
   size: 774252
   timestamp: 1732632769210
 - kind: conda
@@ -16416,6 +17441,7 @@ packages:
   - openssl >=3.0.0,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 210264
   timestamp: 1643442231687
 - kind: conda
@@ -16430,6 +17456,7 @@ packages:
   - openssl >=3.0.0,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 213817
   timestamp: 1643442169866
 - kind: conda
@@ -16445,6 +17472,8 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/six?source=hash-mapping
   size: 14259
   timestamp: 1620240338595
 - kind: conda
@@ -16460,6 +17489,8 @@ packages:
   - python >=3.7
   license: Apache-2.0
   license_family: Apache
+  purls:
+  - pkg:pypi/sniffio?source=hash-mapping
   size: 15064
   timestamp: 1708953086199
 - kind: conda
@@ -16475,6 +17506,8 @@ packages:
   - python >=2
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/snowballstemmer?source=hash-mapping
   size: 58824
   timestamp: 1637143137377
 - kind: conda
@@ -16491,6 +17524,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/soupsieve?source=hash-mapping
   size: 36754
   timestamp: 1693929424267
 - kind: conda
@@ -16524,6 +17559,8 @@ packages:
   - tomli >=2.0
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinx?source=hash-mapping
   size: 1358660
   timestamp: 1721487658869
 - kind: conda
@@ -16541,6 +17578,8 @@ packages:
   - sphinx >=5
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinx-book-theme?source=hash-mapping
   size: 253113
   timestamp: 1718217240940
 - kind: conda
@@ -16557,6 +17596,8 @@ packages:
   - sphinx >=1.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-comments?source=hash-mapping
   size: 8062
   timestamp: 1598556068938
 - kind: conda
@@ -16574,6 +17615,8 @@ packages:
   - sphinx >=1.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-copybutton?source=hash-mapping
   size: 17893
   timestamp: 1734573117732
 - kind: conda
@@ -16591,6 +17634,8 @@ packages:
   - sphinx >=6,<9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-design?source=hash-mapping
   size: 911336
   timestamp: 1734614675610
 - kind: conda
@@ -16609,6 +17654,8 @@ packages:
   - sphinx >=5
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-external-toc?source=hash-mapping
   size: 29093
   timestamp: 1702435239505
 - kind: conda
@@ -16628,6 +17675,8 @@ packages:
   - myst-nb >=1.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinx-jupyterbook-latex?source=hash-mapping
   size: 17809
   timestamp: 1702320091721
 - kind: conda
@@ -16644,6 +17693,8 @@ packages:
   - sphinx >=3
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-multitoc-numbering?source=hash-mapping
   size: 8148
   timestamp: 1615945969181
 - kind: conda
@@ -16660,6 +17711,8 @@ packages:
   - sphinx >=4
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-thebe?source=hash-mapping
   size: 14745
   timestamp: 1708445215853
 - kind: conda
@@ -16677,6 +17730,8 @@ packages:
   - sphinx
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-togglebutton?source=hash-mapping
   size: 12268
   timestamp: 1664390298824
 - kind: conda
@@ -16694,6 +17749,8 @@ packages:
   - sphinx >=5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinxcontrib-applehelp?source=hash-mapping
   size: 29752
   timestamp: 1733754216334
 - kind: conda
@@ -16715,6 +17772,8 @@ packages:
   - sphinx >=3.5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinxcontrib-bibtex?source=hash-mapping
   size: 32595
   timestamp: 1734603350720
 - kind: conda
@@ -16732,6 +17791,8 @@ packages:
   - sphinx >=5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinxcontrib-devhelp?source=hash-mapping
   size: 24536
   timestamp: 1733754232002
 - kind: conda
@@ -16749,6 +17810,8 @@ packages:
   - sphinx >=5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinxcontrib-htmlhelp?source=hash-mapping
   size: 32895
   timestamp: 1733754385092
 - kind: conda
@@ -16765,6 +17828,8 @@ packages:
   - python >=3.9
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinxcontrib-jsmath?source=hash-mapping
   size: 10462
   timestamp: 1733753857224
 - kind: conda
@@ -16782,6 +17847,8 @@ packages:
   - sphinx >=5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinxcontrib-qthelp?source=hash-mapping
   size: 26959
   timestamp: 1733753505008
 - kind: conda
@@ -16799,6 +17866,8 @@ packages:
   - sphinx >=5
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/sphinxcontrib-serializinghtml?source=hash-mapping
   size: 28669
   timestamp: 1733750596111
 - kind: conda
@@ -16818,6 +17887,8 @@ packages:
   - typing-extensions >=4.6.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sqlalchemy?source=hash-mapping
   size: 2804881
   timestamp: 1729066525329
 - kind: conda
@@ -16836,6 +17907,8 @@ packages:
   - typing-extensions >=4.6.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sqlalchemy?source=hash-mapping
   size: 2770491
   timestamp: 1729066732640
 - kind: conda
@@ -16855,6 +17928,8 @@ packages:
   - typing-extensions >=4.6.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/sqlalchemy?source=hash-mapping
   size: 2805289
   timestamp: 1729066624963
 - kind: conda
@@ -16873,6 +17948,7 @@ packages:
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
+  purls: []
   size: 929527
   timestamp: 1730208118175
 - kind: conda
@@ -16892,6 +17968,7 @@ packages:
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
+  purls: []
   size: 883666
   timestamp: 1730208056779
 - kind: conda
@@ -16910,6 +17987,7 @@ packages:
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
+  purls: []
   size: 840459
   timestamp: 1730208324005
 - kind: conda
@@ -16928,6 +18006,8 @@ packages:
   - python >=3.5
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/stack-data?source=hash-mapping
   size: 26205
   timestamp: 1669632203115
 - kind: conda
@@ -16945,6 +18025,7 @@ packages:
   - tzdata
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 15141219
   timestamp: 1727437660028
 - kind: conda
@@ -16962,6 +18043,7 @@ packages:
   - tzdata
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 15500960
   timestamp: 1729794510631
 - kind: conda
@@ -16978,6 +18060,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/tabulate?source=hash-mapping
   size: 37554
   timestamp: 1733589854804
 - kind: conda
@@ -16994,6 +18078,7 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: NCSA
   license_family: MIT
+  purls: []
   size: 207679
   timestamp: 1725491499758
 - kind: conda
@@ -17010,6 +18095,7 @@ packages:
   - ncurses >=6.5,<7.0a0
   license: NCSA
   license_family: MIT
+  purls: []
   size: 221236
   timestamp: 1725491044729
 - kind: conda
@@ -17028,6 +18114,8 @@ packages:
   - tornado >=6.1.0
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/terminado?source=hash-mapping
   size: 22452
   timestamp: 1710262728753
 - kind: conda
@@ -17046,6 +18134,8 @@ packages:
   - tornado >=6.1.0
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/terminado?source=hash-mapping
   size: 22717
   timestamp: 1710265922593
 - kind: conda
@@ -17062,6 +18152,8 @@ packages:
   - webencodings >=0.4
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/tinycss2?source=hash-mapping
   size: 28285
   timestamp: 1729802975370
 - kind: conda
@@ -17077,6 +18169,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3270220
   timestamp: 1699202389792
 - kind: conda
@@ -17092,6 +18185,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3145523
   timestamp: 1699202432999
 - kind: conda
@@ -17108,6 +18202,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3318875
   timestamp: 1699202167581
 - kind: conda
@@ -17123,6 +18218,7 @@ packages:
   - __osx >=11.0
   - tk >=8.6.13,<8.7.0a0
   license: TCL
+  purls: []
   size: 79824
   timestamp: 1719242715383
 - kind: conda
@@ -17138,6 +18234,7 @@ packages:
   - libgcc-ng >=12
   - tk >=8.6.13,<8.7.0a0
   license: TCL
+  purls: []
   size: 91641
   timestamp: 1719242648005
 - kind: conda
@@ -17153,6 +18250,7 @@ packages:
   - __osx >=10.13
   - tk >=8.6.13,<8.7.0a0
   license: TCL
+  purls: []
   size: 81347
   timestamp: 1719242823061
 - kind: conda
@@ -17168,6 +18266,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=hash-mapping
   size: 18203
   timestamp: 1727974767524
 - kind: conda
@@ -17184,6 +18284,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=hash-mapping
   size: 19167
   timestamp: 1733256819729
 - kind: conda
@@ -17202,6 +18304,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: Apache-2.0
   license_family: Apache
+  purls:
+  - pkg:pypi/tornado?source=hash-mapping
   size: 653350
   timestamp: 1724956638966
 - kind: conda
@@ -17219,6 +18323,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: Apache-2.0
   license_family: Apache
+  purls:
+  - pkg:pypi/tornado?source=hash-mapping
   size: 651869
   timestamp: 1724956270046
 - kind: conda
@@ -17237,6 +18343,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: Apache-2.0
   license_family: Apache
+  purls:
+  - pkg:pypi/tornado?source=hash-mapping
   size: 650505
   timestamp: 1724960822818
 - kind: conda
@@ -17252,6 +18360,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/traitlets?source=hash-mapping
   size: 110187
   timestamp: 1713535244513
 - kind: conda
@@ -17266,6 +18376,8 @@ packages:
   depends:
   - python >=3.6
   license: Apache-2.0 AND MIT
+  purls:
+  - pkg:pypi/types-python-dateutil?source=hash-mapping
   size: 21765
   timestamp: 1727940339297
 - kind: conda
@@ -17281,6 +18393,7 @@ packages:
   - typing_extensions 4.12.2 pyha770c72_0
   license: PSF-2.0
   license_family: PSF
+  purls: []
   size: 10097
   timestamp: 1717802659025
 - kind: conda
@@ -17296,6 +18409,8 @@ packages:
   - python >=3.8
   license: PSF-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
   size: 39888
   timestamp: 1717802653893
 - kind: conda
@@ -17311,6 +18426,8 @@ packages:
   - python >=3.6.1
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/typing-utils?source=hash-mapping
   size: 13829
   timestamp: 1622899345711
 - kind: conda
@@ -17323,6 +18440,7 @@ packages:
   sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
   md5: 8ac3367aafb1cc0a068483c580af8015
   license: LicenseRef-Public-Domain
+  purls: []
   size: 122354
   timestamp: 1728047496079
 - kind: conda
@@ -17339,6 +18457,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/uc-micro-py?source=hash-mapping
   size: 11199
   timestamp: 1733784280160
 - kind: conda
@@ -17359,6 +18479,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13756
   timestamp: 1725784148759
 - kind: conda
@@ -17379,6 +18501,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13565
   timestamp: 1725784246850
 - kind: conda
@@ -17398,6 +18522,8 @@ packages:
   - python_abi 3.10.* *_cp310
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 12925
   timestamp: 1725784218557
 - kind: conda
@@ -17418,6 +18544,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13603
   timestamp: 1725784278728
 - kind: conda
@@ -17438,6 +18566,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13858
   timestamp: 1725784165345
 - kind: conda
@@ -17457,6 +18587,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13060
   timestamp: 1725784205661
 - kind: conda
@@ -17477,6 +18609,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13605
   timestamp: 1725784243533
 - kind: conda
@@ -17497,6 +18631,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13904
   timestamp: 1725784191021
 - kind: conda
@@ -17516,6 +18652,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13031
   timestamp: 1725784199719
 - kind: conda
@@ -17535,6 +18673,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13126
   timestamp: 1725784265187
 - kind: conda
@@ -17555,6 +18695,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13916
   timestamp: 1725784177558
 - kind: conda
@@ -17575,6 +18717,8 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
   size: 13689
   timestamp: 1725784235751
 - kind: conda
@@ -17590,6 +18734,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/uri-template?source=hash-mapping
   size: 23999
   timestamp: 1688655976471
 - kind: conda
@@ -17609,6 +18755,8 @@ packages:
   - zstandard >=0.18.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/urllib3?source=hash-mapping
   size: 98076
   timestamp: 1726496531769
 - kind: conda
@@ -17627,6 +18775,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/virtualenv?source=hash-mapping
   size: 3350255
   timestamp: 1732609542072
 - kind: conda
@@ -17642,6 +18792,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/wcwidth?source=hash-mapping
   size: 32709
   timestamp: 1704731373922
 - kind: conda
@@ -17657,6 +18809,8 @@ packages:
   - python >=3.5
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/webcolors?source=hash-mapping
   size: 18378
   timestamp: 1723294800217
 - kind: conda
@@ -17673,6 +18827,8 @@ packages:
   - python >=2.6
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/webencodings?source=hash-mapping
   size: 15600
   timestamp: 1694681458271
 - kind: conda
@@ -17688,6 +18844,8 @@ packages:
   - python >=3.8
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/websocket-client?source=hash-mapping
   size: 47066
   timestamp: 1713923494501
 - kind: conda
@@ -17703,6 +18861,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/wheel?source=hash-mapping
   size: 58585
   timestamp: 1722797131787
 - kind: conda
@@ -17719,6 +18879,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/wheel?source=hash-mapping
   size: 62931
   timestamp: 1733130309598
 - kind: conda
@@ -17735,6 +18897,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 58159
   timestamp: 1727531850109
 - kind: conda
@@ -17753,6 +18916,7 @@ packages:
   - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 27516
   timestamp: 1727634669421
 - kind: conda
@@ -17770,6 +18934,7 @@ packages:
   - xorg-xorgproto
   license: MIT
   license_family: MIT
+  purls: []
   size: 838308
   timestamp: 1727356837875
 - kind: conda
@@ -17786,6 +18951,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 14679
   timestamp: 1727034741045
 - kind: conda
@@ -17801,6 +18967,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 19901
   timestamp: 1727794976192
 - kind: conda
@@ -17817,6 +18984,7 @@ packages:
   - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 50060
   timestamp: 1727752228921
 - kind: conda
@@ -17835,6 +19003,7 @@ packages:
   - xorg-xorgproto
   license: MIT
   license_family: MIT
+  purls: []
   size: 37780
   timestamp: 1727529943015
 - kind: conda
@@ -17854,6 +19023,7 @@ packages:
   - xorg-libx11 >=1.8.10,<2.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 378681
   timestamp: 1727663260353
 - kind: conda
@@ -17870,6 +19040,7 @@ packages:
   - libgcc >=13
   license: MIT
   license_family: MIT
+  purls: []
   size: 565425
   timestamp: 1726846388217
 - kind: conda
@@ -17883,6 +19054,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1 and GPL-2.0
+  purls: []
   size: 418368
   timestamp: 1660346797927
 - kind: conda
@@ -17894,6 +19066,7 @@ packages:
   sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
   md5: 39c6b54e94014701dd157f4f576ed211
   license: LGPL-2.1 and GPL-2.0
+  purls: []
   size: 235693
   timestamp: 1660346961024
 - kind: conda
@@ -17905,6 +19078,7 @@ packages:
   sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
   md5: a72f9d4ea13d55d745ff1ed594747f10
   license: LGPL-2.1 and GPL-2.0
+  purls: []
   size: 238119
   timestamp: 1660346964847
 - kind: conda
@@ -17923,6 +19097,7 @@ packages:
   - xz-gpl-tools 5.6.3 h357f2ed_1
   - xz-tools 5.6.3 hd471939_1
   license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
   size: 23640
   timestamp: 1733407599563
 - kind: conda
@@ -17941,6 +19116,7 @@ packages:
   - xz-gpl-tools 5.6.3 h9a6d368_1
   - xz-tools 5.6.3 h39f12f2_1
   license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
   size: 23692
   timestamp: 1733407556613
 - kind: conda
@@ -17960,6 +19136,7 @@ packages:
   - xz-gpl-tools 5.6.3 hbcc6ac9_1
   - xz-tools 5.6.3 hb9d3cd8_1
   license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
   size: 23477
   timestamp: 1733407455801
 - kind: conda
@@ -17975,6 +19152,7 @@ packages:
   - __osx >=10.13
   - liblzma 5.6.3 hd471939_1
   license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
   size: 33298
   timestamp: 1733407576656
 - kind: conda
@@ -17990,6 +19168,7 @@ packages:
   - __osx >=11.0
   - liblzma 5.6.3 h39f12f2_1
   license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
   size: 33402
   timestamp: 1733407540403
 - kind: conda
@@ -18006,6 +19185,7 @@ packages:
   - libgcc >=13
   - liblzma 5.6.3 hb9d3cd8_1
   license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
   size: 33354
   timestamp: 1733407444641
 - kind: conda
@@ -18021,6 +19201,7 @@ packages:
   - __osx >=11.0
   - liblzma 5.6.3 h39f12f2_1
   license: 0BSD AND LGPL-2.1-or-later
+  purls: []
   size: 81028
   timestamp: 1733407527563
 - kind: conda
@@ -18037,6 +19218,7 @@ packages:
   - libgcc >=13
   - liblzma 5.6.3 hb9d3cd8_1
   license: 0BSD AND LGPL-2.1-or-later
+  purls: []
   size: 90354
   timestamp: 1733407433418
 - kind: conda
@@ -18052,6 +19234,7 @@ packages:
   - __osx >=10.13
   - liblzma 5.6.3 hd471939_1
   license: 0BSD AND LGPL-2.1-or-later
+  purls: []
   size: 80968
   timestamp: 1733407552376
 - kind: conda
@@ -18065,6 +19248,7 @@ packages:
   md5: d7e08fcf8259d742156188e8762b4d20
   license: MIT
   license_family: MIT
+  purls: []
   size: 84237
   timestamp: 1641347062780
 - kind: conda
@@ -18078,6 +19262,7 @@ packages:
   md5: 4bb3f014845110883a3c5ee811fd84b4
   license: MIT
   license_family: MIT
+  purls: []
   size: 88016
   timestamp: 1641347076660
 - kind: conda
@@ -18093,6 +19278,7 @@ packages:
   - libgcc-ng >=9.4.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 89141
   timestamp: 1641346969816
 - kind: conda
@@ -18112,6 +19298,7 @@ packages:
   - libstdcxx >=13
   license: MPL-2.0
   license_family: MOZILLA
+  purls: []
   size: 335528
   timestamp: 1728364029042
 - kind: conda
@@ -18130,6 +19317,7 @@ packages:
   - libsodium >=1.0.20,<1.0.21.0a0
   license: MPL-2.0
   license_family: MOZILLA
+  purls: []
   size: 280870
   timestamp: 1728363954972
 - kind: conda
@@ -18148,6 +19336,7 @@ packages:
   - libsodium >=1.0.20,<1.0.21.0a0
   license: MPL-2.0
   license_family: MOZILLA
+  purls: []
   size: 290634
   timestamp: 1728364170966
 - kind: conda
@@ -18163,6 +19352,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/zipp?source=hash-mapping
   size: 21409
   timestamp: 1726248679175
 - kind: conda
@@ -18179,6 +19370,7 @@ packages:
   - libzlib 1.3.1 h8359307_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 77606
   timestamp: 1727963209370
 - kind: conda
@@ -18196,6 +19388,7 @@ packages:
   - libzlib 1.3.1 hb9d3cd8_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 92286
   timestamp: 1727963153079
 - kind: conda
@@ -18212,6 +19405,7 @@ packages:
   - libzlib 1.3.1 hd23fc13_2
   license: Zlib
   license_family: Other
+  purls: []
   size: 88544
   timestamp: 1727963189976
 - kind: conda
@@ -18233,6 +19427,8 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
   size: 320810
   timestamp: 1725305704555
 - kind: conda
@@ -18253,6 +19449,8 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
   size: 400765
   timestamp: 1725305605347
 - kind: conda
@@ -18274,6 +19472,8 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
   size: 408309
   timestamp: 1725305719512
 - kind: conda
@@ -18289,6 +19489,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 498900
   timestamp: 1714723303098
 - kind: conda
@@ -18305,6 +19506,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 554846
   timestamp: 1714722996770
 - kind: conda
@@ -18320,5 +19522,6 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 405089
   timestamp: 1714723101397

--- a/pixi.toml
+++ b/pixi.toml
@@ -94,12 +94,17 @@ depends-on = ["install-python"]
 pip = ">=24.2,<25"
 maturin = ">=1.7.4,<2"
 pytest = ">=8.3.4,<9"
+pytest-benchmark = ">=5.1.0,<6"
 
 [feature.python.tasks.install-python]
 cmd = "maturin develop --release --manifest-path ./py-phylo2vec/Cargo.toml"
 
 [feature.python.tasks.test]
 cmd = "pytest -vvv ./py-phylo2vec/tests"
+depends-on = ["install-python"]
+
+[feature.python.tasks.benchmark]
+cmd = "pytest ./py-phylo2vec/benchmarks --benchmark-group-by=func --benchmark-warmup=on"
 depends-on = ["install-python"]
 
 # ======== r-phylo2vec ===========

--- a/py-phylo2vec/benchmarks/test_bench.py
+++ b/py-phylo2vec/benchmarks/test_bench.py
@@ -1,0 +1,14 @@
+from phylo2vec import _phylo2vec_core as p2v
+import pytest
+
+@pytest.mark.parametrize("sample_size", [2**8, 2**9, 2**10, 2**11, 2**12, 2**13, 2**14, 2**15, 2**16, 2**17, 2**18])
+def test_to_newick_ordered(benchmark, sample_size):
+    benchmark(p2v.to_newick, p2v.sample(sample_size, True))
+
+@pytest.mark.parametrize("sample_size", [2**8, 2**9, 2**10, 2**11, 2**12, 2**13, 2**14, 2**15, 2**16, 2**17, 2**18])
+def test_to_newick_unordered(benchmark, sample_size):
+    benchmark(p2v.to_newick, p2v.sample(sample_size, False))
+
+@pytest.mark.parametrize("sample_size", [2**8, 2**9, 2**10, 2**11, 2**12, 2**13, 2**14])
+def test_to_vector(benchmark, sample_size):
+    benchmark(p2v.to_vector, p2v.to_newick(p2v.sample(sample_size, True)))


### PR DESCRIPTION
Create a suite of benchmarks for the Rust to python bindings. Uses [pytest-benchmark](https://github.com/ionelmc/pytest-benchmark). There is also potential to create a GH action using this suite with [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark).

## Related Issues
Closes #9