### PR TITLE
ci: Add python version update script and update CD config

### DIFF
--- a/.github/workflows/cd-python.yaml
+++ b/.github/workflows/cd-python.yaml
@@ -29,17 +29,26 @@ jobs:
           python-version: 3.x
       - name: Install dependencies
         run: pip install tomli
-      - name: Update version with timestamp
-        id: update-version
+      - name: Determine and set version
+        id: set-version
         run: |
-          python resources/update_python_version.py
+          if [ "${{ github.event_name }}" == "release" ]; then
+            # Extract version from tag (removing 'v' prefix if present)
+            TAG_VERSION=${GITHUB_REF#refs/tags/}
+            VERSION=${TAG_VERSION#v}
+            echo "Version from release tag: $VERSION"
+
+            # Use the update_python_version.py script with the release version
+            python resources/update_python_version.py $VERSION
+          else
+            # Run the script without parameters to use timestamp versioning
+            python resources/update_python_version.py
+          fi
+
           # Get the updated version from Cargo.toml
           VERSION=$(grep -m 1 'version =' py-phylo2vec/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "Updated version to $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Set version output
-        id: set-version
-        run: echo "version=${{ steps.update-version.outputs.version }}" >> $GITHUB_OUTPUT
 
   linux:
     needs: update-version
@@ -188,7 +197,7 @@ jobs:
     # set in pypi website
     environment: pypi
     if: github.event_name == 'release' && github.event.action == 'published'
-    needs: [linux, musllinux, windows, macos, sdist]
+    needs: [update-version, linux, musllinux, windows, macos, sdist]
     permissions:
       # Use to sign the release artifacts
       id-token: write
@@ -202,9 +211,41 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: 'wheels-*/*'
+      - name: Log version being published
+        run: echo "Publishing version ${{ needs.update-version.outputs.version }} to PyPI"
       - name: Publish to PyPI
         if: "startsWith(github.ref, 'refs/tags/')"
         uses: PyO3/maturin-action@v1
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
+
+  test-release:
+    name: Test Release
+    runs-on: ubuntu-latest
+    # Set the TestPyPI environment,
+    # this needs to be configured in repository settings
+    environment: testpypi
+    # Run only on non-release events (pushes to main/dev or workflow dispatch)
+    if: github.event_name != 'release'
+    needs: [update-version, linux, musllinux, windows, macos, sdist]
+    permissions:
+      # Use to sign the release artifacts
+      id-token: write
+      # Used to upload release artifacts
+      contents: write
+      # Used to generate artifact attestation
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'wheels-*/*'
+      - name: Log version being published
+        run: echo "Publishing version ${{ needs.update-version.outputs.version }} to TestPyPI"
+      - name: Publish to TestPyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --non-interactive --skip-existing --repository-url https://test.pypi.org/legacy/ wheels-*/*

--- a/.github/workflows/cd-python.yaml
+++ b/.github/workflows/cd-python.yaml
@@ -17,7 +17,32 @@ env:
   MATURIN_MANIFEST_PATH: ./py-phylo2vec/Cargo.toml
 
 jobs:
+  # Update version with timestamp
+  update-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: pip install tomli
+      - name: Update version with timestamp
+        id: update-version
+        run: |
+          python resources/update_python_version.py
+          # Get the updated version from Cargo.toml
+          VERSION=$(grep -m 1 'version =' py-phylo2vec/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Updated version to $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Set version output
+        id: set-version
+        run: echo "version=${{ steps.update-version.outputs.version }}" >> $GITHUB_OUTPUT
+
   linux:
+    needs: update-version
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -53,6 +78,7 @@ jobs:
           path: dist
 
   musllinux:
+    needs: update-version
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -84,6 +110,7 @@ jobs:
           path: dist
 
   windows:
+    needs: update-version
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -111,6 +138,7 @@ jobs:
           path: dist
 
   macos:
+    needs: update-version
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -137,6 +165,7 @@ jobs:
           path: dist
 
   sdist:
+    needs: update-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/pixi.toml
+++ b/pixi.toml
@@ -95,6 +95,7 @@ pip = ">=24.2,<25"
 maturin = ">=1.7.4,<2"
 pytest = ">=8.3.4,<9"
 pytest-benchmark = ">=5.1.0,<6"
+tomli = ">=2.0.0,<3"
 
 [feature.python.tasks.install-python]
 cmd = "maturin develop --release --manifest-path ./py-phylo2vec/Cargo.toml"

--- a/resources/update_python_version.py
+++ b/resources/update_python_version.py
@@ -1,0 +1,177 @@
+
+import sys
+import datetime
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ImportError:
+    try:
+        import tomli as tomllib  # Python 3.7+ via pip install tomli
+    except ImportError:
+        import toml as tomllib  # Fallback to toml library
+
+
+def update_cargo_version(cargo_path: Path, new_version: str) -> None:
+    """
+    Update the version string in Cargo.toml file using TOML library.
+
+    Parameters
+    ----------
+    cargo_path : Path
+        Path to the Cargo.toml file
+    new_version : str
+        New version string to set
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    FileNotFoundError
+        If the Cargo.toml file does not exist at the specified path
+    ValueError
+        If the TOML file cannot be parsed or updated
+    """
+    if not cargo_path.exists():
+        raise FileNotFoundError(f"Cargo.toml not found at {cargo_path}")
+
+    # Read the TOML file as text first
+    content = cargo_path.read_text()
+
+    # Parse the TOML content
+    try:
+        # tomllib is read-only, so we need to modify the content as string
+        # and write it back manually
+        toml_dict = tomllib.loads(content)
+
+        # Check if the version key exists in the package section
+        if 'package' in toml_dict and 'version' in toml_dict['package']:
+            old_version = toml_dict['package']['version']
+
+            # If version hasn't changed, no need to update
+            if old_version == new_version:
+                print(f"Version is already set to {new_version}")
+                return
+
+            # Replace the version string in the content
+            version_line = f'version = "{old_version}"'
+            new_version_line = f'version = "{new_version}"'
+            new_content = content.replace(version_line, new_version_line)
+
+            # Write the updated content back to the file
+            cargo_path.write_text(new_content)
+            print(f"Successfully updated version from {old_version} to {new_version}")
+        else:
+            print("No version field found in the package section of the TOML file")
+
+    except Exception as e:
+        raise ValueError(f"Failed to parse or update TOML file: {e}")
+
+
+def get_current_version(cargo_path: Path) -> str:
+    """
+    Get the current version from the Cargo.toml file.
+
+    Parameters
+    ----------
+    cargo_path : Path
+        Path to the Cargo.toml file
+
+    Returns
+    -------
+    str
+        Current version string
+
+    Raises
+    ------
+    FileNotFoundError
+        If the Cargo.toml file does not exist at the specified path
+    ValueError
+        If the TOML file cannot be parsed or the version is not found
+    """
+    if not cargo_path.exists():
+        raise FileNotFoundError(f"Cargo.toml not found at {cargo_path}")
+
+    content = cargo_path.read_text()
+
+    try:
+        toml_dict = tomllib.loads(content)
+        if 'package' in toml_dict and 'version' in toml_dict['package']:
+            return toml_dict['package']['version']
+        else:
+            raise ValueError("No version field found in the package section of the TOML file")
+    except Exception as e:
+        raise ValueError(f"Failed to parse TOML file: {e}")
+
+
+def generate_version_with_timestamp(base_version: str) -> str:
+    """
+    Generate a new version string by appending the current date and time to the base version.
+
+    Parameters
+    ----------
+    base_version : str
+        Base version string (e.g., '0.1.12')
+
+    Returns
+    -------
+    str
+        New version string with timestamp (e.g., '0.1.12.dev202504071437')
+    """
+    now = datetime.datetime.now()
+    timestamp = now.strftime("%Y%m%d%H%M")  # Format: YYYYMMDDHHMM (up to minute)
+
+    # Remove any existing dev version if present
+    if '.dev' in base_version:
+        base_version = base_version.split('.dev')[0]
+
+    return f"{base_version}.dev{timestamp}"
+
+
+def main():
+    """
+    Main function to update the version in Cargo.toml file.
+
+    This function can either use a provided version from command line arguments,
+    or generate a new version based on the current version plus timestamp.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    Exits with code 1 if there's an error.
+
+    Usage:
+    - With argument: python update_python_version.py NEW_VERSION
+    - Without argument: python update_python_version.py
+      (will generate version based on current version + timestamp)
+    """
+    cargo_path = Path(__file__).parents[1] / "py-phylo2vec" / "Cargo.toml"
+
+    try:
+        if len(sys.argv) > 1:
+            # Use provided version
+            new_version = sys.argv[1]
+        else:
+            # Generate version with timestamp
+            current_version = get_current_version(cargo_path)
+            new_version = generate_version_with_timestamp(current_version)
+            print(f"Generated new version: {new_version}")
+
+        # Update the version in the Cargo.toml file
+        update_cargo_version(cargo_path, new_version)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request includes significant updates to the continuous deployment workflow and introduces a new script for version management. The most important changes include adding a new job to update the version using a timestamp, modifying existing jobs to depend on this new job, and adding a new Python script for version management.

### Workflow updates:

* [`.github/workflows/cd-python.yaml`](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R20-R54): Added a new `update-version` job to determine and set the version based on the event type (release or timestamp). All existing jobs (`linux`, `musllinux`, `windows`, `macos`, `sdist`, and `publish`) now depend on this new job. Additionally, a new `test-release` job has been added to handle non-release events. [[1]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R20-R54) [[2]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R90) [[3]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R122) [[4]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R150) [[5]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R177) [[6]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265L162-R200) [[7]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R214-R251)

### Dependency updates:

* [`pixi.toml`](diffhunk://#diff-b092682f0ad15a352f9fa2b0a67c992454b586275ee76b74a5839ab9afdf9894R98): Added `tomli` as a new dependency to handle TOML file parsing in the new version management script.

### New script for version management:

* [`resources/update_python_version.py`](diffhunk://#diff-3e1c7512ffb0377bdb0b66b69ee787fa07a89d1e0333c7581e604913b4d5a283R1-R177): Introduced a new script to manage version updates. This script can either use a provided version or generate a new version based on the current version and timestamp. It updates the `Cargo.toml` file accordingly.This pull request includes updates to the continuous deployment workflow for a Python project, adding a new job to update the version with a timestamp and ensuring other jobs depend on this version update. Additionally, a new script is introduced to handle the version update in the `Cargo.toml` file.

### Workflow Updates:
* Added a new job `update-version` in `.github/workflows/cd-python.yaml` to update the version with a timestamp before other jobs run. This job includes steps to install dependencies and run a Python script to update the version.
* Modified existing jobs (`linux`, `musllinux`, `windows`, `macos`, `sdist`) in `.github/workflows/cd-python.yaml` to depend on the `update-version` job. [[1]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R81) [[2]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R113) [[3]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R141) [[4]](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R168)

### Dependency Updates:
* Added `tomli` as a dependency in `pixi.toml` to support reading TOML files in the new version update script.

### New Script:
* Introduced `resources/update_python_version.py` to update the version in `Cargo.toml` using a timestamp. This script reads the current version, generates a new version with a timestamp, and updates the `Cargo.toml` file accordingly.