### PR TITLE
fix: Add maturin repository env var for testpypi

### DIFF
--- a/.github/workflows/cd-python.yaml
+++ b/.github/workflows/cd-python.yaml
@@ -261,6 +261,8 @@ jobs:
         run: echo "Publishing version ${{ needs.linux.outputs.version }} to TestPyPI"
       - name: Publish to TestPyPI
         uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_REPOSITORY: testpypi
         with:
           command: upload
-          args: --non-interactive --skip-existing --repository-url https://test.pypi.org/legacy/ wheels-*/*
+          args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/cd-python.yaml` file to improve the publishing process to TestPyPI by setting an environment variable and updating the command arguments.

Improvements to the publishing process:

* [`.github/workflows/cd-python.yaml`](diffhunk://#diff-3d3ec9b0267b381030bac62bc8c1fba27934e0747af2b539b83a62643cc93265R264-R268): Added the `MATURIN_REPOSITORY` environment variable and updated the `args` to simplify the upload command.