### PR TITLE
refactor: Add iterative to_vector python implementation

### DIFF
--- a/py-phylo2vec/phylo2vec/utils/vector.py
+++ b/py-phylo2vec/phylo2vec/utils/vector.py
@@ -10,7 +10,7 @@ from ete3 import Tree
 from phylo2vec.base.to_newick import _get_ancestry, to_newick
 from phylo2vec.base.to_vector import (
     _build_vector,
-    _find_cherries,
+    _order_cherries,
     to_vector,
 )
 from phylo2vec.utils.validation import check_v
@@ -63,7 +63,7 @@ def reorder_v(reorder_method, v_old, label_mapping_old):
     )
 
     # Re-build v
-    v_new = _build_vector(_find_cherries(ancestry_new))
+    v_new = _build_vector(_order_cherries(ancestry_new))
 
     return v_new, label_mapping_new
 

--- a/py-phylo2vec/tests/test_v2newick2v.py
+++ b/py-phylo2vec/tests/test_v2newick2v.py
@@ -8,10 +8,10 @@ from ete3 import Tree
 from .config import MIN_N_LEAVES, MAX_N_LEAVES, N_REPEATS
 from phylo2vec.base import to_newick, to_vector
 from phylo2vec.base.to_vector import (
-    _find_cherries,
+    _order_cherries,
     _order_cherries_no_parents,
-    _reduce,
-    _reduce_no_parents,
+    _get_cherries,
+    _get_cherries_no_parents,
 )
 from phylo2vec.utils import sample_vector
 
@@ -50,9 +50,9 @@ def test_cherries_no_parents(n_leaves):
         v = sample_vector(n_leaves)
         newick = to_newick(v)
         newick_no_parents = Tree(newick).write(format=9)
-        cherries = _find_cherries(_reduce(newick))
+        cherries = _order_cherries(_get_cherries(newick))
         cherries_no_parents = _order_cherries_no_parents(
-            _reduce_no_parents(newick_no_parents)
+            _get_cherries_no_parents(newick_no_parents)
         )
 
         assert np.array_equal(cherries, cherries_no_parents)


### PR DESCRIPTION
Ported over from https://github.com/uw-ssec/phylo2vec/pull/110

This new python implementation of Python `to_vector` is currently faster than the Rust-Python bindings. This PR switches the top level Python API to use native Python rather than Rust-Python.