### PR TITLE
refactor: Add fenwick tree prefix sum implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ trees/# pixi environments
 
 # Experimental notebooks folder
 notebooks/
+
+# Benchmarks output files
+.benchmarks/

--- a/pixi.toml
+++ b/pixi.toml
@@ -107,7 +107,7 @@ cmd = "pytest -vvv ./py-phylo2vec/tests"
 depends-on = ["install-python"]
 
 [feature.python.tasks.benchmark]
-cmd = "pytest ./py-phylo2vec/benchmarks --benchmark-group-by=func --benchmark-warmup=on"
+cmd = "pytest ./py-phylo2vec/benchmarks --benchmark-autosave --benchmark-group-by=func --benchmark-warmup=on"
 depends-on = ["install-python"]
 
 # ======== r-phylo2vec ===========

--- a/py-phylo2vec/benchmarks/test_bench.py
+++ b/py-phylo2vec/benchmarks/test_bench.py
@@ -9,6 +9,6 @@ def test_to_newick_ordered(benchmark, sample_size):
 def test_to_newick_unordered(benchmark, sample_size):
     benchmark(p2v.to_newick_from_vector, p2v.sample_vector(sample_size, False))
 
-@pytest.mark.parametrize("sample_size", [2**8, 2**9, 2**10, 2**11, 2**12, 2**13, 2**14])
+@pytest.mark.parametrize("sample_size", [2**8, 2**9, 2**10, 2**11, 2**12, 2**13, 2**14, 2**15, 2**16, 2**17, 2**18])
 def test_to_vector(benchmark, sample_size):
     benchmark(p2v.to_vector, p2v.to_newick_from_vector(p2v.sample_vector(sample_size, True)))


### PR DESCRIPTION
Adds [fenwick tree](https://en.wikipedia.org/wiki/Fenwick_tree) implementation to significantly improve performance of `build_vector`. Previous approach had $O(n^2)$ lookup and $O(n)$ insert. New approach has $O(nlogn)$ lookup and $O(nlogn)$ insert.

Also updates benchmark script to test larger inputs `to_vector` can now quickly run.