### PR TITLE
Faster build_newick from pairs instead of ancestry

### DIFF
--- a/phylo2vec/benches/benchmarks/core.rs
+++ b/phylo2vec/benches/benchmarks/core.rs
@@ -1,11 +1,10 @@
 use criterion::{criterion_group, BenchmarkId, Criterion};
 use phylo2vec::tree_vec::ops;
 use phylo2vec::utils::sample_vector;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 use std::time::Duration;
 
-/// Input sizes for benchmarks (powers of 2)
-const SAMPLE_SIZES: Range<u32> = 8..20; // 2^8 to 2^19 (256 to 524288)
+const SAMPLE_SIZES: RangeInclusive<u32> = 1..=10;
 
 /// Benchmark to_newick with both ordered and unordered inputs
 fn bench_to_newick(c: &mut Criterion) {
@@ -16,7 +15,7 @@ fn bench_to_newick(c: &mut Criterion) {
     );
 
     for i in SAMPLE_SIZES {
-        let sample_size = 2_i32.checked_pow(i).unwrap() as usize;
+        let sample_size = 10000 * i as usize;
 
         // Benchmark ordered case
         group.bench_with_input(
@@ -25,7 +24,7 @@ fn bench_to_newick(c: &mut Criterion) {
             |b, &size| {
                 b.iter(|| {
                     let v = sample_vector(size, true);
-                    ops::to_newick(&v)
+                    ops::to_newick_from_vector(&v)
                 });
             },
         );
@@ -37,7 +36,7 @@ fn bench_to_newick(c: &mut Criterion) {
             |b, &size| {
                 b.iter(|| {
                     let v = sample_vector(size, false);
-                    ops::to_newick(&v)
+                    ops::to_newick_from_vector(&v)
                 });
             },
         );
@@ -53,14 +52,14 @@ fn bench_to_vector(c: &mut Criterion) {
         criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
     );
     for i in SAMPLE_SIZES {
-        let sample_size = 2_i32.checked_pow(i).unwrap() as usize;
+        let sample_size = 10000 * i as usize;
         group.bench_with_input(
             BenchmarkId::from_parameter(sample_size),
             &sample_size,
             |b, &size| {
                 // Generate the Newick string once outside the benchmark loop
                 let v = sample_vector(size, true);
-                let newick = ops::to_newick(&v);
+                let newick = ops::to_newick_from_vector(&v);
 
                 // Benchmark only the to_vector operation
                 b.iter(|| ops::to_vector(&newick));

--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     utils::{check_m, is_unordered},
 };
 use matrix::parse_matrix;
-use newick::build_newick_from_ancestry_with_bls;
+use newick::build_newick_from_pairs_with_bls;
 
 pub use vector::{
     build_vector, cophenetic_distances, find_coords_of_first_leaf, get_ancestry, get_pairs,
@@ -37,9 +37,9 @@ pub fn to_newick_from_matrix(m: &Vec<Vec<f32>>) -> String {
     // First, check the matrix structure for validity
     check_m(m);
 
-    let (v, bls) = parse_matrix(&m);
-    let ancestry = get_ancestry(&v);
-    build_newick_from_ancestry_with_bls(&ancestry, &bls)
+    let (v, bls) = parse_matrix(m);
+    let pairs: Pairs = get_pairs(&v);
+    build_newick_from_pairs_with_bls(&pairs, &bls)
 }
 
 /// Recover a Phylo2Vec vector from a rooted tree (in Newick format)
@@ -176,9 +176,9 @@ mod tests {
     #[rstest]
     #[case(vec![
         vec![0.0, 0.9, 0.4],
-        vec![0.0, 0.8, 3.0],
+        vec![0.0, 0.8, 3.12],
         vec![3.0, 0.4, 0.5],
-    ], "(((0:0.9,2:0.4)4:0.8,3:3.0)5:0.4,1:0.5)6;")]
+    ], "(((0:0.9,2:0.4)4:0.8,3:3.12)5:0.4,1:0.5)6;")]
     #[case(vec![
         vec![0.0, 0.1, 0.2],
     ], "(0:0.1,1:0.2)2;")]
@@ -186,7 +186,7 @@ mod tests {
         vec![0.0, 0.0, 0.0],
         vec![0.0, 0.1, 0.2],
         vec![1.0, 0.5, 0.7],
-    ], "((0:0.1,2:0.2)5:0.5,(1:0.0,3:0.0)4:0.7)6;")]
+    ], "((0:0.1,2:0.2)5:0.5,(1:0,3:0)4:0.7)6;")]
     fn test_to_newick_from_matrix(#[case] m: Vec<Vec<f32>>, #[case] expected: &str) {
         let newick = to_newick_from_matrix(&m);
         assert_eq!(newick, expected);

--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -12,7 +12,7 @@ use newick::build_newick_from_pairs_with_bls;
 
 pub use vector::{
     build_vector, cophenetic_distances, find_coords_of_first_leaf, get_ancestry, get_pairs,
-    get_pairs_avl, make_avl_tree, order_cherries, order_cherries_no_parents,
+    order_cherries, order_cherries_no_parents,
 };
 
 pub use newick::{
@@ -22,13 +22,9 @@ pub use newick::{
 
 /// Recover a rooted tree (in Newick format) from a Phylo2Vec vector
 pub fn to_newick_from_vector(v: &Vec<usize>) -> String {
-    // // let ancestry: Ancestry = get_ancestry(&v);
-    // // build_newick(&ancestry)
-    let pairs: Pairs = match is_unordered(v) {
-        true => get_pairs_avl(v),
-        false => get_pairs(v),
-    };
-
+    // let ancestry: Ancestry = get_ancestry(&v);
+    // build_newick(&ancestry)
+    let pairs: Pairs = get_pairs(v);
     build_newick_from_pairs(&pairs)
 }
 

--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -3,21 +3,33 @@ pub mod matrix;
 pub mod newick;
 pub mod vector;
 
-use crate::{tree_vec::types::Ancestry, utils::check_m};
+use crate::{
+    tree_vec::types::{Ancestry, Pairs},
+    utils::{check_m, is_unordered},
+};
 use matrix::parse_matrix;
-use newick::build_newick_with_bls;
+use newick::build_newick_from_ancestry_with_bls;
 
 pub use vector::{
     build_vector, cophenetic_distances, find_coords_of_first_leaf, get_ancestry, get_pairs,
-    get_pairs_avl, order_cherries, order_cherries_no_parents,
+    get_pairs_avl, make_avl_tree, order_cherries, order_cherries_no_parents,
 };
 
-pub use newick::{build_newick, get_cherries, get_cherries_no_parents, has_parents};
+pub use newick::{
+    build_newick_from_ancestry, build_newick_from_pairs, get_cherries, get_cherries_no_parents,
+    has_parents,
+};
 
 /// Recover a rooted tree (in Newick format) from a Phylo2Vec vector
 pub fn to_newick_from_vector(v: &Vec<usize>) -> String {
-    let ancestry: Ancestry = get_ancestry(&v);
-    build_newick(&ancestry)
+    // // let ancestry: Ancestry = get_ancestry(&v);
+    // // build_newick(&ancestry)
+    let pairs: Pairs = match is_unordered(v) {
+        true => get_pairs_avl(v),
+        false => get_pairs(v),
+    };
+
+    build_newick_from_pairs(&pairs)
 }
 
 /// Recover a rooted tree (in Newick format) from a Phylo2Vec matrix
@@ -27,7 +39,7 @@ pub fn to_newick_from_matrix(m: &Vec<Vec<f32>>) -> String {
 
     let (v, bls) = parse_matrix(&m);
     let ancestry = get_ancestry(&v);
-    build_newick_with_bls(&ancestry, &bls)
+    build_newick_from_ancestry_with_bls(&ancestry, &bls)
 }
 
 /// Recover a Phylo2Vec vector from a rooted tree (in Newick format)

--- a/phylo2vec/src/tree_vec/ops/newick/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/newick/mod.rs
@@ -1,6 +1,6 @@
 use std::num::IntErrorKind;
 
-use crate::tree_vec::types::Ancestry;
+use crate::tree_vec::types::{Ancestry, Pairs};
 use std::collections::HashMap;
 
 mod newick_patterns;
@@ -217,94 +217,6 @@ pub fn get_cherries_no_parents_with_bls(newick: &str) -> (Ancestry, Vec<[f32; 2]
     (ancestry, bls)
 }
 
-// The recursive function that builds the Newick string
-fn _build_newick_recursive_inner(p: usize, ancestry: &Ancestry) -> String {
-    let leaf_max = ancestry.len();
-
-    // Extract the children (c1, c2) and ignore the parent from the ancestry tuple
-    let [c1, c2, _] = ancestry[p - leaf_max - 1];
-
-    // Recursive calls for left and right children, checking if they are leaves or internal nodes
-    let left = if c1 > leaf_max {
-        _build_newick_recursive_inner(c1, ancestry)
-    } else {
-        c1.to_string() // It's a leaf node, just convert to string
-    };
-
-    let right = if c2 > leaf_max {
-        _build_newick_recursive_inner(c2, ancestry)
-    } else {
-        c2.to_string() // It's a leaf node, just convert to string
-    };
-
-    // Create the Newick string in the form (left, right)p
-    format!("({},{}){}", left, right, p)
-}
-
-/// Build newick string from the ancestry matrix and branch lengths
-pub fn build_newick_with_bls(ancestry: &Ancestry, branch_lengths: &Vec<[f32; 2]>) -> String {
-    let n_max = ancestry.len();
-
-    // Extract the last entry in ancestry and branch lengths
-    let [c1, c2, p] = ancestry[n_max - 1];
-    let [b1, b2] = branch_lengths[n_max - 1];
-
-    // Initialize the Newick string with the last entry
-    // .1 here specifies 1 decimal place in the Newick string result - this can be changed as needed.
-    let mut newick = format!("({}:{:.1},{}:{:.1}){};", c1, b1, c2, b2, p);
-
-    // Keep track of node indices for replacement
-    let mut node_idxs = HashMap::new();
-    node_idxs.insert(c1, 1);
-    node_idxs.insert(c2, 2 + format!("{}:{:.1}", c1, b1).len());
-
-    // Queue for processing nodes
-    let mut queue = Vec::new();
-
-    if c1 > n_max {
-        queue.push(c1);
-    }
-    if c2 > n_max {
-        queue.push(c2);
-    }
-
-    // Process the remaining entries in ancestry
-    for _ in 1..n_max {
-        if let Some(next_parent) = queue.pop() {
-            let idx = next_parent - n_max - 1;
-
-            let [c1, c2, p] = ancestry[idx];
-            let [b1, b2] = branch_lengths[idx];
-
-            // Build the sub-Newick string
-            let sub_newick = format!("({}:{:.1},{}:{:.1}){}", c1, b1, c2, b2, p);
-
-            // Replace the placeholder in the Newick string
-            if let Some(&start_idx) = node_idxs.get(&p) {
-                newick = format!(
-                    "{}{}{}",
-                    &newick[..start_idx],
-                    sub_newick,
-                    &newick[start_idx + format!("{}", p).len()..]
-                );
-            }
-
-            // Update node indices
-            node_idxs.insert(c1, node_idxs[&p] + 1);
-            node_idxs.insert(c2, node_idxs[&c1] + 1 + format!("{}:{:.1}", c1, b1).len());
-            // Add children to the queue if they are internal nodes
-            if c1 > n_max {
-                queue.push(c1);
-            }
-            if c2 > n_max {
-                queue.push(c2);
-            }
-        }
-    }
-
-    newick
-}
-
 /// Remove parent labels from the Newick string
 ///
 /// # Example
@@ -366,13 +278,138 @@ pub fn find_num_leaves(newick: &str) -> usize {
     return result.len();
 }
 
+// The recursive function that builds the Newick string
+fn _build_newick_recursive_inner(p: usize, ancestry: &Ancestry) -> String {
+    let leaf_max = ancestry.len();
+
+    // Extract the children (c1, c2) and ignore the parent from the ancestry tuple
+    let [c1, c2, _] = ancestry[p - leaf_max - 1];
+
+    // Recursive calls for left and right children, checking if they are leaves or internal nodes
+    let left = if c1 > leaf_max {
+        _build_newick_recursive_inner(c1, ancestry)
+    } else {
+        c1.to_string() // It's a leaf node, just convert to string
+    };
+
+    let right = if c2 > leaf_max {
+        _build_newick_recursive_inner(c2, ancestry)
+    } else {
+        c2.to_string() // It's a leaf node, just convert to string
+    };
+
+    // Create the Newick string in the form (left, right)p
+    format!("({},{}){}", left, right, p)
+}
+
 /// Build newick string from the ancestry matrix
-pub fn build_newick(ancestry: &Ancestry) -> String {
+pub fn build_newick_from_ancestry(ancestry: &Ancestry) -> String {
     // Get the root node, which is the parent value of the last ancestry element
     let root = ancestry.last().unwrap()[2];
 
     // Build the Newick string starting from the root, and append a semicolon
     format!("{};", _build_newick_recursive_inner(root, ancestry))
+}
+
+pub fn build_newick_from_pairs(pairs: &Pairs) -> String {
+    let num_leaves = pairs.len() + 1;
+
+    // Faster than map+collect for some reason
+    let mut cache: Vec<String> = Vec::with_capacity(num_leaves);
+    for i in 0..num_leaves {
+        cache.push(i.to_string());
+    }
+
+    for (i, &(c1, c2)) in pairs.iter().enumerate() {
+        // std::mem::take helps efficient swapping of values like std::move in C++
+        let s1 = std::mem::take(&mut cache[c1]);
+        let s2 = std::mem::take(&mut cache[c2]);
+        // Parent node (not needed in theory, but left for legacy reasons)
+        let sp = (num_leaves + i).to_string();
+
+        // https://github.com/hoodie/concatenation_benchmarks-rs
+        // 3 = 2 parentheses + 1 comma
+        let capacity = s1.len() + s2.len() + sp.len() + 3;
+        let mut sub_newick = String::with_capacity(capacity);
+        sub_newick.push('(');
+        sub_newick.push_str(&s1);
+        sub_newick.push(',');
+        sub_newick.push_str(&s2);
+        sub_newick.push(')');
+        sub_newick.push_str(&sp);
+
+        cache[c1] = sub_newick;
+    }
+
+    cache[0].push(';');
+    cache[0].clone()
+}
+
+/// Build newick string from the ancestry matrix and branch lengths
+pub fn build_newick_from_ancestry_with_bls(
+    ancestry: &Ancestry,
+    branch_lengths: &Vec<[f32; 2]>,
+) -> String {
+    let n_max = ancestry.len();
+
+    // Extract the last entry in ancestry and branch lengths
+    let [c1, c2, p] = ancestry[n_max - 1];
+    let [b1, b2] = branch_lengths[n_max - 1];
+
+    // Initialize the Newick string with the last entry
+    // .1 here specifies 1 decimal place in the Newick string result - this can be changed as needed.
+    let mut newick = format!("({}:{:.1},{}:{:.1}){};", c1, b1, c2, b2, p);
+
+    // Keep track of node indices for replacement
+    let mut node_idxs = HashMap::new();
+    node_idxs.insert(c1, 1);
+    node_idxs.insert(c2, 2 + format!("{}:{:.1}", c1, b1).len());
+
+    // Queue for processing nodes
+    let mut queue = Vec::new();
+
+    if c1 > n_max {
+        queue.push(c1);
+    }
+    if c2 > n_max {
+        queue.push(c2);
+    }
+
+    // Process the remaining entries in ancestry
+    for _ in 1..n_max {
+        if let Some(next_parent) = queue.pop() {
+            let idx = next_parent - n_max - 1;
+
+            let [c1, c2, p] = ancestry[idx];
+            let [b1, b2] = branch_lengths[idx];
+
+            // Build the sub-Newick string
+            let sub_newick = format!("({}:{:.1},{}:{:.1}){}", c1, b1, c2, b2, p);
+
+            // Replace the placeholder in the Newick string
+            if let Some(&start_idx) = node_idxs.get(&p) {
+                newick = format!(
+                    "{}{}{}",
+                    &newick[..start_idx],
+                    sub_newick,
+                    &newick[start_idx + format!("{}", p).len()..]
+                );
+            }
+
+            // Update node indices
+            node_idxs.insert(c1, node_idxs[&p] + 1);
+            node_idxs.insert(c2, node_idxs[&c1] + 1 + format!("{}:{:.1}", c1, b1).len());
+            // Add children to the queue if they are internal nodes
+            if c1 > n_max {
+                queue.push(c1);
+            }
+            if c2 > n_max {
+                queue.push(c2);
+            }
+        }
+    }
+
+    newick
 }
 
 #[cfg(test)]

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -1,9 +1,7 @@
 use crate::tree_vec::ops::avl::AVLTree;
-use crate::tree_vec::types::{Ancestry, Pair, PairsVec};
+use crate::tree_vec::types::{Ancestry, Pair, Pairs};
 use crate::utils::is_unordered;
-use core::num;
 use std::collections::HashMap;
-use std::usize;
 
 /// Get the pair of nodes from the Phylo2Vec vector
 /// using a vector data structure and for loops
@@ -16,9 +14,9 @@ use std::usize;
 /// let v = vec![0, 0, 0, 1, 3, 3, 1, 4, 4];
 /// let pairs = get_pairs(&v);
 /// ```
-pub fn get_pairs(v: &Vec<usize>) -> PairsVec {
+pub fn get_pairs(v: &Vec<usize>) -> Pairs {
     let num_of_leaves: usize = v.len();
-    let mut pairs: PairsVec = Vec::with_capacity(num_of_leaves);
+    let mut pairs: Pairs = Vec::with_capacity(num_of_leaves);
 
     // First loop (reverse iteration)
     for i in (0..num_of_leaves).rev() {
@@ -55,17 +53,7 @@ pub fn get_pairs(v: &Vec<usize>) -> PairsVec {
     pairs
 }
 
-/// Get the pair of nodes from the Phylo2Vec vector
-/// using an AVL tree data structure implementation.
-///
-/// # Example
-/// ```
-/// use phylo2vec::tree_vec::ops::vector::get_pairs_avl;
-///
-/// let v = vec![0, 0, 0, 1, 3, 3, 1, 4, 4];
-/// let pairs = get_pairs_avl(&v);
-/// ```
-pub fn get_pairs_avl(v: &Vec<usize>) -> PairsVec {
+pub fn make_avl_tree(v: &[usize]) -> AVLTree {
     // AVL tree implementation of get_pairs
     let k = v.len();
     let mut avl_tree = AVLTree::new();
@@ -82,6 +70,21 @@ pub fn get_pairs_avl(v: &Vec<usize>) -> PairsVec {
         }
     }
 
+    avl_tree
+}
+
+/// Get the pair of nodes from the Phylo2Vec vector
+/// using an AVL tree data structure implementation.
+///
+/// # Example
+/// ```
+/// use phylo2vec::tree_vec::ops::vector::get_pairs_avl;
+///
+/// let v = vec![0, 0, 0, 1, 3, 3, 1, 4, 4];
+/// let pairs = get_pairs_avl(&v);
+/// ```
+pub fn get_pairs_avl(v: &Vec<usize>) -> Pairs {
+    let avl_tree: AVLTree = make_avl_tree(v);
     avl_tree.get_pairs()
 }
 
@@ -102,7 +105,7 @@ pub fn get_pairs_avl(v: &Vec<usize>) -> PairsVec {
 ///
 /// v[1] = 2 is somewhat similar: we create a new branch from R that yields leaf 2
 pub fn get_ancestry(v: &Vec<usize>) -> Ancestry {
-    let pairs: PairsVec;
+    let pairs: Pairs;
 
     // Determine the implementation to use
     // based on whether this is an ordered

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -6,15 +6,7 @@ use std::collections::HashMap;
 /// Get the pair of nodes from the Phylo2Vec vector
 /// using a vector data structure and for loops
 /// implementation.
-///
-/// # Example
-/// ```
-/// use phylo2vec::tree_vec::ops::vector::get_pairs;
-///
-/// let v = vec![0, 0, 0, 1, 3, 3, 1, 4, 4];
-/// let pairs = get_pairs(&v);
-/// ```
-pub fn get_pairs(v: &Vec<usize>) -> Pairs {
+fn get_pairs_for(v: &Vec<usize>) -> Pairs {
     let num_of_leaves: usize = v.len();
     let mut pairs: Pairs = Vec::with_capacity(num_of_leaves);
 
@@ -53,7 +45,7 @@ pub fn get_pairs(v: &Vec<usize>) -> Pairs {
     pairs
 }
 
-pub fn make_avl_tree(v: &[usize]) -> AVLTree {
+fn make_avl_tree(v: &[usize]) -> AVLTree {
     // AVL tree implementation of get_pairs
     let k = v.len();
     let mut avl_tree = AVLTree::new();
@@ -75,17 +67,27 @@ pub fn make_avl_tree(v: &[usize]) -> AVLTree {
 
 /// Get the pair of nodes from the Phylo2Vec vector
 /// using an AVL tree data structure implementation.
+fn get_pairs_avl(v: &Vec<usize>) -> Pairs {
+    make_avl_tree(v).get_pairs()
+}
+
+/// Get the pair of nodes from the Phylo2Vec vector
+/// Implementation is determined based on whether
+/// the vector is unordered or ordered.
 ///
 /// # Example
 /// ```
-/// use phylo2vec::tree_vec::ops::vector::get_pairs_avl;
+/// use phylo2vec::tree_vec::ops::vector::get_pairs;
 ///
 /// let v = vec![0, 0, 0, 1, 3, 3, 1, 4, 4];
-/// let pairs = get_pairs_avl(&v);
+/// let pairs = get_pairs(&v);
 /// ```
-pub fn get_pairs_avl(v: &Vec<usize>) -> Pairs {
-    let avl_tree: AVLTree = make_avl_tree(v);
-    avl_tree.get_pairs()
+pub fn get_pairs(v: &Vec<usize>) -> Pairs {
+    if is_unordered(v) {
+        get_pairs_avl(v)
+    } else {
+        get_pairs_for(v)
+    }
 }
 
 /// Get the ancestry of the Phylo2Vec vector
@@ -105,19 +107,7 @@ pub fn get_pairs_avl(v: &Vec<usize>) -> Pairs {
 ///
 /// v[1] = 2 is somewhat similar: we create a new branch from R that yields leaf 2
 pub fn get_ancestry(v: &Vec<usize>) -> Ancestry {
-    let pairs: Pairs;
-
-    // Determine the implementation to use
-    // based on whether this is an ordered
-    // or unordered tree vector
-    match is_unordered(&v) {
-        true => {
-            pairs = get_pairs_avl(&v);
-        }
-        false => {
-            pairs = get_pairs(&v);
-        }
-    }
+    let pairs: Pairs = get_pairs(v);
     let num_of_leaves = v.len();
     // Initialize Ancestry with capacity `k`
     let mut ancestry: Ancestry = Vec::with_capacity(num_of_leaves);

--- a/phylo2vec/src/tree_vec/types.rs
+++ b/phylo2vec/src/tree_vec/types.rs
@@ -1,8 +1,8 @@
 /// A type alias for the Pair type, which is a tuple representing (child1, child2)
 pub type Pair = (usize, usize);
 
+/// A type alias for the Pairs type, which is a vector of pairs representing [child1, child2]
+pub type Pairs = Vec<Pair>;
+
 /// A type alias for the Ancestry type, which is a vector of vectors representing [child1, child2, parent]
 pub type Ancestry = Vec<[usize; 3]>;
-
-/// A type alias for the PairsVec type, which is a vector of tuples representing (child1, child2)
-pub type PairsVec = Vec<Pair>;

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -36,7 +36,7 @@ fn get_ancestry(input_vector: Vec<usize>) -> Vec<[usize; 3]> {
 
 #[pyfunction]
 fn build_newick(input_ancestry: Vec<[usize; 3]>) -> String {
-    let newick_string: String = ops::newick::build_newick(&input_ancestry);
+    let newick_string: String = ops::newick::build_newick_from_ancestry(&input_ancestry);
     newick_string
 }
 


### PR DESCRIPTION
This PR might be too heavy to include in the next release, as it involves several changes to accelerate newick building. 

In essence, new functions are proposed to build a newick string from get_pairs() instead of get_ancestry, thus removing an extra step. Moreover, the new function gets rid of recursion. 

![image](https://github.com/user-attachments/assets/e3db128d-0640-42df-82b7-67d914de229a)
